### PR TITLE
Change interfaces to match more appropriate auth functionality

### DIFF
--- a/app/src/community/java/com/twilio/video/app/auth/CommunityAuthenticator.kt
+++ b/app/src/community/java/com/twilio/video/app/auth/CommunityAuthenticator.kt
@@ -24,7 +24,7 @@ import io.reactivex.Observable
 import io.reactivex.Single
 import timber.log.Timber
 
-class CommunityAuthenticator @JvmOverloads constructor(
+class CommunityAuthenticator constructor(
     private val preferences: SharedPreferences
 ) : Authenticator {
 

--- a/app/src/main/java/com/twilio/video/app/auth/AuthModule.java
+++ b/app/src/main/java/com/twilio/video/app/auth/AuthModule.java
@@ -22,6 +22,10 @@ import android.content.SharedPreferences;
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
 import com.twilio.video.app.ApplicationModule;
 import com.twilio.video.app.ApplicationScope;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import dagger.Module;
 import dagger.Provides;
 
@@ -35,8 +39,8 @@ public class AuthModule {
             Application application,
             SharedPreferences sharedPreferences) {
         Context context = application.getApplicationContext();
-        return new FirebaseAuthenticator(
-                firebaseWrapper,
+        List<AuthenticationProvider> authenticators = new ArrayList<>();
+        authenticators.add(
                 new GoogleAuthenticator(
                         new FirebaseWrapper(),
                         context,
@@ -44,8 +48,10 @@ public class AuthModule {
                         new GoogleSignInWrapper(),
                         new GoogleSignInOptionsBuilderWrapper(GoogleSignInOptions.DEFAULT_SIGN_IN),
                         new GoogleAuthProviderWrapper(),
-                        sharedPreferences),
-                new EmailAuthenticator(firebaseWrapper, sharedPreferences));
+                        sharedPreferences)
+        );
+        authenticators.add(new EmailAuthenticator(firebaseWrapper, sharedPreferences));
+        return new FirebaseAuthenticator(firebaseWrapper, authenticators);
     }
 
     @Provides

--- a/app/src/main/java/com/twilio/video/app/auth/AuthenticationProvider.kt
+++ b/app/src/main/java/com/twilio/video/app/auth/AuthenticationProvider.kt
@@ -1,0 +1,10 @@
+package com.twilio.video.app.auth
+
+import io.reactivex.Observable
+
+interface AuthenticationProvider {
+
+    fun login(loginEventObservable: Observable<LoginEvent>): Observable<LoginResult>
+
+    fun logout()
+}

--- a/app/src/main/java/com/twilio/video/app/auth/EmailAuthenticator.kt
+++ b/app/src/main/java/com/twilio/video/app/auth/EmailAuthenticator.kt
@@ -31,12 +31,10 @@ class EmailAuthenticator @JvmOverloads constructor(
     private val firebaseWrapper: FirebaseWrapper,
     private val sharedPreferences: SharedPreferences,
     private val disposables: CompositeDisposable = CompositeDisposable()
-) : Authenticator {
+) : AuthenticationProvider {
     override fun logout() {
         firebaseWrapper.instance.signOut()
     }
-
-    override fun loggedIn() = firebaseWrapper.instance.currentUser != null
 
     override fun login(loginEventObservable: Observable<LoginEvent>): Observable<LoginResult> {
         return Observable.create<LoginResult> { observable ->

--- a/app/src/main/java/com/twilio/video/app/auth/FirebaseAuthenticator.kt
+++ b/app/src/main/java/com/twilio/video/app/auth/FirebaseAuthenticator.kt
@@ -4,18 +4,21 @@ import io.reactivex.Observable
 
 class FirebaseAuthenticator(
     private val firebaseWrapper: FirebaseWrapper,
-    private val googleAuthenticator: GoogleAuthenticator,
-    private val emailAuthenticator: EmailAuthenticator
+    private val authenticationProviders: List<AuthenticationProvider>
 ) : Authenticator {
 
-    override fun login(loginEventObservable: Observable<LoginEvent>) =
-            // TODO Figure out a better way to only subscribe to one authenticator at a time
-            googleAuthenticator.login(loginEventObservable).mergeWith(emailAuthenticator.login(loginEventObservable))
+    override fun login(loginEventObservable: Observable<LoginEvent>): Observable<LoginResult> {
+        // TODO Figure out a better way to only subscribe to one authenticator at a time
+        val observables : MutableList<Observable<LoginResult>> = mutableListOf()
+        authenticationProviders.forEach {
+            observables.add(it.login(loginEventObservable))
+        }
+        return Observable.merge(observables)
+    }
 
     override fun loggedIn() = firebaseWrapper.instance.currentUser != null
 
     override fun logout() {
-        googleAuthenticator.logout()
-        emailAuthenticator.logout()
+        authenticationProviders.forEach { it.logout() }
     }
 }

--- a/app/src/main/java/com/twilio/video/app/auth/GoogleAuthenticator.kt
+++ b/app/src/main/java/com/twilio/video/app/auth/GoogleAuthenticator.kt
@@ -29,7 +29,7 @@ class GoogleAuthenticator @JvmOverloads constructor(
     private val googleAuthProviderWrapper: GoogleAuthProviderWrapper,
     private val sharedPreferences: SharedPreferences,
     private val disposables: CompositeDisposable = CompositeDisposable()
-) : Authenticator {
+) : AuthenticationProvider {
 
     private val googleSignInClient: GoogleSignInClient = buildGoogleSignInClient(context)
 
@@ -58,8 +58,6 @@ class GoogleAuthenticator @JvmOverloads constructor(
                     })
         }
     }
-
-    override fun loggedIn() = firebaseWrapper.instance.currentUser != null
 
     override fun logout() {
         googleSignInClient.signOut()


### PR DESCRIPTION
Change interfaces to match more appropriate auth functionality. Also made FirebaseAuthenticator reference a list of authenticators for better testability and maintainability.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
