### PR TITLE
Filter out cameras that do not support PRIVATE image and support MONO  or NIR while creating camera pair

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion '28.0.3'
 
     lintOptions {

--- a/app/src/main/java/com/twilio/video/app/util/CameraCapturerCompat.java
+++ b/app/src/main/java/com/twilio/video/app/util/CameraCapturerCompat.java
@@ -17,8 +17,17 @@
 package com.twilio.video.app.util;
 
 import android.content.Context;
+import android.graphics.ImageFormat;
+import android.hardware.camera2.CameraAccessException;
+import android.hardware.camera2.CameraCharacteristics;
+import android.hardware.camera2.CameraManager;
+import android.hardware.camera2.CameraMetadata;
+import android.hardware.camera2.params.StreamConfigurationMap;
+import android.os.Build;
 import android.util.Pair;
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
 import com.twilio.video.Camera2Capturer;
 import com.twilio.video.CameraCapturer;
 import com.twilio.video.VideoCapturer;
@@ -33,9 +42,12 @@ public class CameraCapturerCompat {
     private Camera2Capturer camera2Capturer;
     private Pair<CameraCapturer.CameraSource, String> frontCameraPair;
     private Pair<CameraCapturer.CameraSource, String> backCameraPair;
+    private CameraManager cameraManager;
 
     public CameraCapturerCompat(Context context, CameraCapturer.CameraSource cameraSource) {
-        if (Camera2Capturer.isSupported(context)) {
+        if (Camera2Capturer.isSupported(context) && isLollipopApiSupported()) {
+            cameraManager =
+                    (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
             setCameraPairs(context);
             Camera2Capturer.Listener camera2Listener =
                     new Camera2Capturer.Listener() {
@@ -105,14 +117,17 @@ public class CameraCapturerCompat {
         return camera1Capturer != null;
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     private void setCameraPairs(Context context) {
         Camera2Enumerator camera2Enumerator = new Camera2Enumerator(context);
         for (String cameraId : camera2Enumerator.getDeviceNames()) {
-            if (camera2Enumerator.isFrontFacing(cameraId)) {
-                frontCameraPair = new Pair<>(CameraCapturer.CameraSource.FRONT_CAMERA, cameraId);
-            }
-            if (camera2Enumerator.isBackFacing(cameraId)) {
-                backCameraPair = new Pair<>(CameraCapturer.CameraSource.BACK_CAMERA, cameraId);
+            if (isCameraIdSupported(cameraId)) {
+                if (camera2Enumerator.isFrontFacing(cameraId)) {
+                    frontCameraPair = new Pair<>(CameraCapturer.CameraSource.FRONT_CAMERA, cameraId);
+                }
+                if (camera2Enumerator.isBackFacing(cameraId)) {
+                    backCameraPair = new Pair<>(CameraCapturer.CameraSource.BACK_CAMERA, cameraId);
+                }
             }
         }
     }
@@ -131,5 +146,43 @@ public class CameraCapturerCompat {
         } else {
             return backCameraPair.first;
         }
+    }
+
+    private boolean isLollipopApiSupported() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    private boolean isCameraIdSupported(String cameraId) {
+        boolean isMonoChromeSupported = false;
+        boolean isPrivateImageFormatSupported;
+        CameraCharacteristics cameraCharacteristics;
+        try {
+            cameraCharacteristics = cameraManager.getCameraCharacteristics(cameraId);
+        } catch (CameraAccessException e) {
+            e.printStackTrace();
+            return false;
+        }
+        /*
+         * This is a temporary work around for a RuntimeException that occurs on devices which contain cameras
+         * that do not support ImageFormat.PRIVATE output formats. A long term fix is currently in development.
+         * https://github.com/twilio/video-quickstart-android/issues/431
+         */
+        final StreamConfigurationMap streamMap =
+                cameraCharacteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
+        isPrivateImageFormatSupported = streamMap.isOutputSupportedFor(ImageFormat.PRIVATE);
+
+        /*
+         * Read the color filter arrangements of the camera to filter out the ones that support
+         * SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_MONO or SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_NIR.
+         * Visit this link for details on supported values - https://developer.android.com/reference/android/hardware/camera2/CameraCharacteristics#SENSOR_INFO_COLOR_FILTER_ARRANGEMENT
+         */
+        final int colorFilterArrangement = cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            isMonoChromeSupported = (colorFilterArrangement == CameraMetadata.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_MONO
+                    || colorFilterArrangement == CameraMetadata.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_NIR) ? true : false;
+        }
+        return isPrivateImageFormatSupported && !isMonoChromeSupported;
     }
 }


### PR DESCRIPTION
Some of the newer Android Phones come with more that two camera. Added code to filter out the cameras that support [MONO](https://developer.android.com/reference/android/hardware/camera2/CameraMetadata.html#SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_MONO) or [NIR](https://developer.android.com/reference/android/hardware/camera2/CameraMetadata.html#SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_NIR).

## Validation

- Validated running the app locally and confirmed the correct cameras are selected.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
