### PR TITLE
Change AppCenter cli group to public distribution group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
             sudo npm install webpack
             echo no | sudo npm install -g appcenter-cli
             appcenter login --token $APPCENTER_API_TOKEN
-            appcenter distribute release -f app/build/outputs/apk/internal/release/app-internal-release.apk -g Collaborators --app nico-hokeyapp-dzyz/Video-App-Internal
+            appcenter distribute release -f app/build/outputs/apk/internal/release/app-internal-release.apk -g Testers --app nico-hokeyapp-dzyz/Video-App-Internal
 
 workflows:
   version: 2


### PR DESCRIPTION
## Description

Change AppCenter cli group to public distribution group

## Breakdown

- Change app center cli distribution group parameter

## Validation

- Validated CI and AppCenter

## Additional Notes

N/A

## Submission Checklist

 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
