### PR TITLE
AHOYAPPS-253: Add app link for video app URLs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,8 @@
             android:name=".ui.room.RoomActivity"
             android:configChanges="orientation|screenSize"
             android:theme="@style/AppTheme.Lobby">
-            <intent-filter android:autoVerify="true">
+            <intent-filter android:autoVerify="true"
+                tools:targetApi="m">
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>


### PR DESCRIPTION
## Description

Added app link for video app URLs.

## Breakdown

- Updated app manifests to support app links for react video app URLs
- Created assetsLink.json in react video app https://github.com/twilio/twilio-video-app-react/pull/52

## Validation

- Tested video app links on a physical device to ensure navigation to release variants of the app.

## Additional Notes

N/A

## Submission Checklist

 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
