### PR TITLE
Video Service Implementation and Room Abstraction

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -142,13 +142,15 @@ dependencies {
     def espresso = "androidx.test.espresso:espresso-core:$espressoVersion"
     def testCore = 'androidx.test:core:1.2.0'
     def junitExtensions = 'androidx.test.ext:junit-ktx:1.1.1'
+    def lifecycleVersion = '2.2.0'
 
     implementation 'com.twilio:twilio-android-env:1.0.0'
     implementation videoAndroidSdkDep
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
-    implementation 'androidx.lifecycle:lifecycle-service:2.2.0'
+    implementation "androidx.lifecycle:lifecycle-service:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-livedata:$lifecycleVersion"
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation "com.appyvet:materialrangebar:1.3"
     implementation "com.jakewharton:butterknife:$butterknifeVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -148,6 +148,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
+    implementation 'androidx.lifecycle:lifecycle-service:2.2.0'
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation "com.appyvet:materialrangebar:1.3"
     implementation "com.jakewharton:butterknife:$butterknifeVersion"

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/BackgroundSupportTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/BackgroundSupportTest.kt
@@ -12,7 +12,6 @@ import com.twilio.video.app.screen.clickDisconnectButton
 import com.twilio.video.app.screen.clickJoinRoomButton
 import com.twilio.video.app.screen.enterRoomName
 import com.twilio.video.app.ui.splash.SplashActivity
-import com.twilio.video.app.util.clearTask
 import com.twilio.video.app.util.retryEspressoAction
 import com.twilio.video.app.util.uiDevice
 import org.junit.Rule
@@ -37,8 +36,7 @@ class BackgroundSupportTest : BaseUITest() {
         retryEspressoAction { assertRoomIsConnected() }
 
         uiDevice().run {
-            // TODO Replace with scenario call once app uses single activity
-            clearTask()
+            pressHome()
 
             openNotification()
 

--- a/app/src/androidTest/java/com/twilio/video/app/util/UiAutomatorExtensions.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/util/UiAutomatorExtensions.kt
@@ -2,26 +2,5 @@ package com.twilio.video.app.util
 
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiSelector
-import timber.log.Timber
 
 fun uiDevice(): UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-
-fun UiDevice.clearTask(swipeAttempts: Int = 10 ) {
-    pressRecentApps()
-
-    var currentAttempt = 1
-    val centerScreenX = displayWidth / 2
-    val centerScreenY = displayHeight / 2
-    while (currentAttempt <= swipeAttempts) {
-        Timber.d("Clear all tasks attempt $currentAttempt")
-        swipe(centerScreenX, centerScreenY, displayWidth, centerScreenY, 50)
-        val uiObject = findObject(UiSelector().text("Clear all"))
-        if (uiObject.exists()) {
-            uiObject.click()
-            break
-        } else {
-            currentAttempt++
-        }
-    }
-}

--- a/app/src/community/java/com/twilio/video/app/VideoApplicationComponent.java
+++ b/app/src/community/java/com/twilio/video/app/VideoApplicationComponent.java
@@ -22,6 +22,7 @@ import com.twilio.video.app.ui.CommunityScreenSelectorModule;
 import com.twilio.video.app.ui.login.CommunityLoginActivityModule;
 import com.twilio.video.app.ui.room.RoomActivityModule;
 import com.twilio.video.app.ui.room.RoomManagerModule;
+import com.twilio.video.app.ui.room.VideoServiceModule;
 import com.twilio.video.app.ui.settings.SettingsActivityModule;
 import com.twilio.video.app.ui.settings.SettingsFragmentModule;
 import com.twilio.video.app.ui.splash.SplashActivityModule;
@@ -42,6 +43,7 @@ import dagger.android.AndroidInjectionModule;
         RoomActivityModule.class,
         SettingsActivityModule.class,
         SettingsFragmentModule.class,
+        VideoServiceModule.class,
         RoomManagerModule.class
     }
 )

--- a/app/src/community/java/com/twilio/video/app/VideoApplicationComponent.java
+++ b/app/src/community/java/com/twilio/video/app/VideoApplicationComponent.java
@@ -21,6 +21,7 @@ import com.twilio.video.app.data.CommunityDataModule;
 import com.twilio.video.app.ui.CommunityScreenSelectorModule;
 import com.twilio.video.app.ui.login.CommunityLoginActivityModule;
 import com.twilio.video.app.ui.room.RoomActivityModule;
+import com.twilio.video.app.ui.room.RoomManagerModule;
 import com.twilio.video.app.ui.settings.SettingsActivityModule;
 import com.twilio.video.app.ui.settings.SettingsFragmentModule;
 import com.twilio.video.app.ui.splash.SplashActivityModule;
@@ -40,7 +41,8 @@ import dagger.android.AndroidInjectionModule;
         CommunityLoginActivityModule.class,
         RoomActivityModule.class,
         SettingsActivityModule.class,
-        SettingsFragmentModule.class
+        SettingsFragmentModule.class,
+        RoomManagerModule.class
     }
 )
 public interface VideoApplicationComponent {

--- a/app/src/internal/java/com/twilio/video/app/VideoApplicationComponent.java
+++ b/app/src/internal/java/com/twilio/video/app/VideoApplicationComponent.java
@@ -22,6 +22,7 @@ import com.twilio.video.app.data.api.VideoAppServiceModule;
 import com.twilio.video.app.ui.ScreenSelectorModule;
 import com.twilio.video.app.ui.login.LoginActivityModule;
 import com.twilio.video.app.ui.room.RoomActivityModule;
+import com.twilio.video.app.ui.room.RoomManagerModule;
 import com.twilio.video.app.ui.settings.SettingsActivityModule;
 import com.twilio.video.app.ui.settings.SettingsFragmentModule;
 import com.twilio.video.app.ui.splash.SplashActivityModule;
@@ -42,7 +43,8 @@ import dagger.android.AndroidInjectionModule;
         LoginActivityModule.class,
         RoomActivityModule.class,
         SettingsActivityModule.class,
-        SettingsFragmentModule.class
+        SettingsFragmentModule.class,
+        RoomManagerModule.class
     }
 )
 public interface VideoApplicationComponent {

--- a/app/src/internal/java/com/twilio/video/app/VideoApplicationComponent.java
+++ b/app/src/internal/java/com/twilio/video/app/VideoApplicationComponent.java
@@ -23,6 +23,7 @@ import com.twilio.video.app.ui.ScreenSelectorModule;
 import com.twilio.video.app.ui.login.LoginActivityModule;
 import com.twilio.video.app.ui.room.RoomActivityModule;
 import com.twilio.video.app.ui.room.RoomManagerModule;
+import com.twilio.video.app.ui.room.VideoServiceModule;
 import com.twilio.video.app.ui.settings.SettingsActivityModule;
 import com.twilio.video.app.ui.settings.SettingsFragmentModule;
 import com.twilio.video.app.ui.splash.SplashActivityModule;
@@ -44,6 +45,7 @@ import dagger.android.AndroidInjectionModule;
         RoomActivityModule.class,
         SettingsActivityModule.class,
         SettingsFragmentModule.class,
+        VideoServiceModule.class,
         RoomManagerModule.class
     }
 )

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,7 @@
             android:theme="@style/AppTheme.LoginScreen"
             android:windowSoftInputMode="adjustResize|stateAlwaysHidden"/>
         <activity
+            android:launchMode="singleTop"
             android:name=".ui.room.RoomActivity"
             android:configChanges="orientation|screenSize"
             android:theme="@style/AppTheme.Lobby">

--- a/app/src/main/java/com/twilio/video/app/VideoService.kt
+++ b/app/src/main/java/com/twilio/video/app/VideoService.kt
@@ -33,7 +33,7 @@ class VideoService : LifecycleService() {
     private var serviceHandler: ServiceHandler? = null
 
     companion object {
-        fun startForeground(context: Context) {
+        fun startService(context: Context) {
             Intent(context, VideoService::class.java).let { intent ->
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     context.startForegroundService(intent)
@@ -41,6 +41,10 @@ class VideoService : LifecycleService() {
                     context.startService(intent)
                 }
             }
+        }
+
+        fun stopService(context: Context) {
+            Intent(context, VideoService::class.java).let { context.stopService(it) }
         }
     }
 

--- a/app/src/main/java/com/twilio/video/app/VideoService.kt
+++ b/app/src/main/java/com/twilio/video/app/VideoService.kt
@@ -110,7 +110,7 @@ class VideoService : LifecycleService() {
 
     private fun bindRoomEvents(nullableRoomEvent: RoomEvent?) {
         nullableRoomEvent?.let { roomEvent ->
-            when(roomEvent) {
+            when (roomEvent) {
                 is Disconnected -> {
                     stopSelf()
                 }

--- a/app/src/main/java/com/twilio/video/app/VideoService.kt
+++ b/app/src/main/java/com/twilio/video/app/VideoService.kt
@@ -15,9 +15,10 @@ import android.os.Process
 import androidx.core.app.NotificationCompat
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.Observer
+import com.twilio.video.Room.State.DISCONNECTED
 import com.twilio.video.app.ui.room.RoomActivity
 import com.twilio.video.app.ui.room.RoomEvent
-import com.twilio.video.app.ui.room.RoomEvent.Disconnected
+import com.twilio.video.app.ui.room.RoomEvent.RoomState
 import com.twilio.video.app.ui.room.RoomManager
 import dagger.android.AndroidInjection
 import timber.log.Timber
@@ -110,10 +111,8 @@ class VideoService : LifecycleService() {
 
     private fun bindRoomEvents(nullableRoomEvent: RoomEvent?) {
         nullableRoomEvent?.let { roomEvent ->
-            when (roomEvent) {
-                is Disconnected -> {
-                    stopSelf()
-                }
+            if (roomEvent is RoomState && roomEvent.room.state == DISCONNECTED) {
+                stopSelf()
             }
         }
     }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -1167,8 +1167,6 @@ public class RoomActivity extends BaseActivity {
                             Video.connect(
                                     RoomActivity.this, connectOptionsBuilder.build(), roomManager);
 
-                    VideoService.Companion.startForeground(this);
-
                     return room;
                 });
     }
@@ -1457,6 +1455,7 @@ public class RoomActivity extends BaseActivity {
             this.room = roomEvent.getRoom();
             requestPermissions();
             if (roomEvent instanceof Connected) {
+                VideoService.Companion.startForeground(this);
                 initializeRoom();
             }
             if (roomEvent instanceof Disconnected) {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -26,6 +26,7 @@ import static com.twilio.video.app.R.drawable.ic_volume_up_white_24dp;
 import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -1480,6 +1481,11 @@ public class RoomActivity extends BaseActivity {
                 }
             }
             if (roomEvent instanceof ConnectFailure) {
+                new AlertDialog.Builder(this, R.style.AppTheme_Dialog)
+                        .setTitle(getString(R.string.room_screen_connection_failure_title))
+                        .setMessage(getString(R.string.room_screen_connection_failure_message))
+                        .setNeutralButton("OK", null)
+                        .show();
                 removeAllParticipants();
                 setAudioFocus(false);
             }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -108,6 +108,13 @@ import com.twilio.video.app.data.api.TokenService;
 import com.twilio.video.app.data.api.VideoAppService;
 import com.twilio.video.app.data.api.model.RoomProperties;
 import com.twilio.video.app.data.api.model.Topology;
+import com.twilio.video.app.ui.room.RoomEvent.ConnectFailure;
+import com.twilio.video.app.ui.room.RoomEvent.Connected;
+import com.twilio.video.app.ui.room.RoomEvent.Connecting;
+import com.twilio.video.app.ui.room.RoomEvent.Disconnected;
+import com.twilio.video.app.ui.room.RoomEvent.DominantSpeakerChanged;
+import com.twilio.video.app.ui.room.RoomEvent.ParticipantConnected;
+import com.twilio.video.app.ui.room.RoomEvent.ParticipantDisconnected;
 import com.twilio.video.app.ui.settings.SettingsActivity;
 import com.twilio.video.app.util.CameraCapturerCompat;
 import com.twilio.video.app.util.EnvUtil;
@@ -1416,42 +1423,43 @@ public class RoomActivity extends BaseActivity {
 
     private void bindRoomEvents(RoomEvent roomEvent) {
         if (roomEvent != null) {
-            if (roomEvent instanceof RoomEvent.Connected) {
+            if (roomEvent instanceof Connecting) {
+                updateUi(((Connecting) roomEvent).getRoom());
+            }
+            if (roomEvent instanceof Connected) {
                 initializeRoom();
             }
-            if (roomEvent instanceof RoomEvent.Disconnected) {
+            if (roomEvent instanceof Disconnected) {
                 removeAllParticipants();
                 RoomActivity.this.room = null;
                 RoomActivity.this.localParticipant = null;
                 RoomActivity.this.localParticipantSid = LOCAL_PARTICIPANT_STUB_SID;
 
-                updateUi(((RoomEvent.Disconnected) roomEvent).getRoom());
+                updateUi(((Disconnected) roomEvent).getRoom());
                 updateStats();
 
                 setAudioFocus(false);
             }
-            if (roomEvent instanceof RoomEvent.ConnectFailure) {
+            if (roomEvent instanceof ConnectFailure) {
                 removeAllParticipants();
-                updateUi(((RoomEvent.ConnectFailure) roomEvent).getRoom());
+                updateUi(((ConnectFailure) roomEvent).getRoom());
                 setAudioFocus(false);
             }
-            if (roomEvent instanceof RoomEvent.ParticipantConnected) {
+            if (roomEvent instanceof ParticipantConnected) {
                 boolean renderAsPrimary = room.getRemoteParticipants().size() == 1;
                 addParticipant(
-                        ((RoomEvent.ParticipantConnected) roomEvent).getRemoteParticipant(),
-                        renderAsPrimary);
+                        ((ParticipantConnected) roomEvent).getRemoteParticipant(), renderAsPrimary);
 
                 updateStatsUI(sharedPreferences.getBoolean(Preferences.ENABLE_STATS, false));
             }
-            if (roomEvent instanceof RoomEvent.ParticipantDisconnected) {
-                removeParticipant(
-                        ((RoomEvent.ParticipantDisconnected) roomEvent).getRemoteParticipant());
+            if (roomEvent instanceof ParticipantDisconnected) {
+                removeParticipant(((ParticipantDisconnected) roomEvent).getRemoteParticipant());
 
                 updateStatsUI(sharedPreferences.getBoolean(Preferences.ENABLE_STATS, false));
             }
-            if (roomEvent instanceof RoomEvent.DominantSpeakerChanged) {
+            if (roomEvent instanceof DominantSpeakerChanged) {
                 RemoteParticipant remoteParticipant =
-                        ((RoomEvent.DominantSpeakerChanged) roomEvent).getRemoteParticipant();
+                        ((DominantSpeakerChanged) roomEvent).getRemoteParticipant();
 
                 if (remoteParticipant == null) {
                     participantController.setDominantSpeaker(null);

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -1170,7 +1170,9 @@ public class RoomActivity extends BaseActivity {
 
                     room =
                             Video.connect(
-                                    RoomActivity.this, connectOptionsBuilder.build(), roomManager);
+                                    RoomActivity.this,
+                                    connectOptionsBuilder.build(),
+                                    roomManager.getRoomListener());
 
                     return room;
                 });

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -1469,6 +1469,7 @@ public class RoomActivity extends BaseActivity {
                     case DISCONNECTED:
                         removeAllParticipants();
                         localParticipant = null;
+                        room = null;
                         localParticipantSid = LOCAL_PARTICIPANT_STUB_SID;
                         updateStats();
                         setAudioFocus(false);

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -517,13 +517,8 @@ public class RoomActivity extends BaseActivity {
 
     @OnClick(R.id.disconnect)
     void disconnectButtonClick() {
-        if (room != null) {
-            Timber.i("Exiting room");
-            room.disconnect();
-
-            stopScreenCapture();
-            stopService(new Intent(this, VideoService.class));
-        }
+        roomManager.disconnect();
+        stopScreenCapture();
     }
 
     @OnClick(R.id.local_audio_image_button)

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -299,7 +299,6 @@ public class RoomActivity extends BaseActivity {
         // Setup Activity
         statsScheduler = new StatsScheduler();
         obtainVideoConstraints();
-        requestPermissions();
     }
 
     @Override
@@ -383,8 +382,6 @@ public class RoomActivity extends BaseActivity {
         inflater.inflate(R.menu.room_menu, menu);
         settingsMenuItem = menu.findItem(R.id.settings_menu_item);
 
-        roomManager.getViewEvents().observe(this, this::bindRoomEvents);
-
         return true;
     }
 
@@ -398,6 +395,9 @@ public class RoomActivity extends BaseActivity {
 
         // Screen sharing only available on lollipop and up
         screenCaptureMenuItem.setVisible(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP);
+
+        requestPermissions();
+        roomManager.getViewEvents().observe(this, this::bindRoomEvents);
 
         return true;
     }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -344,6 +344,7 @@ public class RoomActivity extends BaseActivity {
     @Override
     protected void onDestroy() {
         // Reset the speakerphone
+        VideoService.Companion.stopService(this);
         audioManager.setSpeakerphoneOn(false);
         // Teardown tracks
         if (localAudioTrack != null) {
@@ -1465,7 +1466,7 @@ public class RoomActivity extends BaseActivity {
                 State state = room.getState();
                 switch (state) {
                     case CONNECTED:
-                        VideoService.Companion.startForeground(this);
+                        VideoService.Companion.startService(this);
                         initializeRoom();
                         break;
                     case DISCONNECTED:

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -785,11 +785,6 @@ public class RoomActivity extends BaseActivity {
         if (cameraVideoTrack != null) {
             localVideoTrackNames.put(
                     cameraVideoTrack.getName(), getString(R.string.camera_video_track));
-
-            // Share camera video track if we are connected to room
-            if (localParticipant != null) {
-                localParticipant.publishTrack(cameraVideoTrack);
-            }
         } else {
             Snackbar.make(
                             primaryVideoView,
@@ -1368,6 +1363,8 @@ public class RoomActivity extends BaseActivity {
             localParticipant = room.getLocalParticipant();
             if (localParticipant != null) {
                 localParticipantSid = localParticipant.getSid();
+
+                localParticipant.publishTrack(cameraVideoTrack);
 
                 setAudioFocus(true);
                 updateStats();

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -783,10 +783,14 @@ public class RoomActivity extends BaseActivity {
     private void setupLocalMedia() {
         if (localAudioTrack == null && !isAudioMuted) {
             localAudioTrack = LocalAudioTrack.create(this, true, MICROPHONE_TRACK_NAME);
+            if (room != null && localParticipant != null)
+                localParticipant.publishTrack(localAudioTrack);
         }
         if (cameraVideoTrack == null && !isVideoMuted) {
             setupLocalVideoTrack();
             renderLocalParticipantStub();
+            if (room != null && localParticipant != null)
+                localParticipant.publishTrack(cameraVideoTrack);
         }
     }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -309,6 +309,7 @@ public class RoomActivity extends BaseActivity {
         displayName = sharedPreferences.getString(Preferences.DISPLAY_NAME, null);
         updateUi(room, isAppLinkProvided);
         restoreCameraTrack();
+        initializeRoom();
         updateStats();
     }
 
@@ -1362,50 +1363,54 @@ public class RoomActivity extends BaseActivity {
         return this::renderItemAsPrimary;
     }
 
-    private void initializeRoom(Room room) {
-        localParticipant = room.getLocalParticipant();
-        if (localParticipant != null) {
-            localParticipantSid = localParticipant.getSid();
+    private void initializeRoom() {
+        if (room != null) {
+            localParticipant = room.getLocalParticipant();
+            if (localParticipant != null) {
+                localParticipantSid = localParticipant.getSid();
 
-            setAudioFocus(true);
-            updateStats();
+                setAudioFocus(true);
+                updateStats();
 
-            // remove primary view
-            participantController.removePrimary();
+                // remove primary view
+                participantController.removePrimary();
 
-            // add local thumb and "click" on it to make primary
-            participantController.addThumb(
-                    localParticipantSid,
-                    getString(R.string.you),
-                    cameraVideoTrack,
-                    localAudioTrack == null,
-                    cameraCapturer.getCameraSource() == CameraCapturer.CameraSource.FRONT_CAMERA,
-                    isNetworkQualityEnabled());
+                // add local thumb and "click" on it to make primary
+                participantController.addThumb(
+                        localParticipantSid,
+                        getString(R.string.you),
+                        cameraVideoTrack,
+                        localAudioTrack == null,
+                        cameraCapturer.getCameraSource()
+                                == CameraCapturer.CameraSource.FRONT_CAMERA,
+                        isNetworkQualityEnabled());
 
-            localParticipant.setListener(
-                    new LocalParticipantListener(
-                            participantController.getThumb(localParticipantSid, cameraVideoTrack)));
-            participantController.getThumb(localParticipantSid, cameraVideoTrack).callOnClick();
+                localParticipant.setListener(
+                        new LocalParticipantListener(
+                                participantController.getThumb(
+                                        localParticipantSid, cameraVideoTrack)));
+                participantController.getThumb(localParticipantSid, cameraVideoTrack).callOnClick();
 
-            // add existing room participants thumbs
-            boolean isFirstParticipant = true;
-            for (RemoteParticipant remoteParticipant : room.getRemoteParticipants()) {
-                addParticipant(remoteParticipant, isFirstParticipant);
-                isFirstParticipant = false;
-                if (room.getDominantSpeaker() != null) {
-                    if (room.getDominantSpeaker().getSid().equals(remoteParticipant.getSid())) {
-                        VideoTrack videoTrack =
-                                (remoteParticipant.getRemoteVideoTracks().size() > 0)
-                                        ? remoteParticipant
-                                                .getRemoteVideoTracks()
-                                                .get(0)
-                                                .getRemoteVideoTrack()
-                                        : null;
-                        if (videoTrack != null) {
-                            ParticipantView participantView =
-                                    participantController.getThumb(
-                                            remoteParticipant.getSid(), videoTrack);
-                            participantController.setDominantSpeaker(participantView);
+                // add existing room participants thumbs
+                boolean isFirstParticipant = true;
+                for (RemoteParticipant remoteParticipant : room.getRemoteParticipants()) {
+                    addParticipant(remoteParticipant, isFirstParticipant);
+                    isFirstParticipant = false;
+                    if (room.getDominantSpeaker() != null) {
+                        if (room.getDominantSpeaker().getSid().equals(remoteParticipant.getSid())) {
+                            VideoTrack videoTrack =
+                                    (remoteParticipant.getRemoteVideoTracks().size() > 0)
+                                            ? remoteParticipant
+                                                    .getRemoteVideoTracks()
+                                                    .get(0)
+                                                    .getRemoteVideoTrack()
+                                            : null;
+                            if (videoTrack != null) {
+                                ParticipantView participantView =
+                                        participantController.getThumb(
+                                                remoteParticipant.getSid(), videoTrack);
+                                participantController.setDominantSpeaker(participantView);
+                            }
                         }
                     }
                 }
@@ -1418,7 +1423,7 @@ public class RoomActivity extends BaseActivity {
             this.room = roomEvent.getRoom();
             requestPermissions();
             if (roomEvent instanceof Connected) {
-                initializeRoom(room);
+                initializeRoom();
             }
             if (roomEvent instanceof Disconnected) {
                 removeAllParticipants();

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -401,12 +401,6 @@ public class RoomActivity extends BaseActivity {
 
         inflater.inflate(R.menu.room_menu, menu);
         settingsMenuItem = menu.findItem(R.id.settings_menu_item);
-
-        return true;
-    }
-
-    @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
         // Grab menu items for updating later
         switchCameraMenuItem = menu.findItem(R.id.switch_camera_menu_item);
         pauseVideoMenuItem = menu.findItem(R.id.pause_video_menu_item);

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomEvent.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomEvent.kt
@@ -1,0 +1,13 @@
+package com.twilio.video.app.ui.room
+
+import com.twilio.video.RemoteParticipant
+import com.twilio.video.Room
+
+sealed class RoomEvent {
+    data class Connected(val room: Room) : RoomEvent()
+    data class Disconnected(val room: Room) : RoomEvent()
+    data class ConnectFailure(val room: Room) : RoomEvent()
+    data class ParticipantConnected(val room: Room, val remoteParticipant: RemoteParticipant) : RoomEvent()
+    data class ParticipantDisconnected(val room: Room, val remoteParticipant: RemoteParticipant) : RoomEvent()
+    data class DominantSpeakerChanged(val room: Room, val remoteParticipant: RemoteParticipant?) : RoomEvent()
+}

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomEvent.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomEvent.kt
@@ -3,12 +3,12 @@ package com.twilio.video.app.ui.room
 import com.twilio.video.RemoteParticipant
 import com.twilio.video.Room
 
-sealed class RoomEvent {
-    data class Connecting(val room: Room) : RoomEvent()
-    data class Connected(val room: Room) : RoomEvent()
-    data class Disconnected(val room: Room) : RoomEvent()
-    data class ConnectFailure(val room: Room) : RoomEvent()
-    data class ParticipantConnected(val room: Room, val remoteParticipant: RemoteParticipant) : RoomEvent()
-    data class ParticipantDisconnected(val room: Room, val remoteParticipant: RemoteParticipant) : RoomEvent()
-    data class DominantSpeakerChanged(val room: Room, val remoteParticipant: RemoteParticipant?) : RoomEvent()
+sealed class RoomEvent(val room: Room) {
+    class Connecting(room: Room) : RoomEvent(room)
+    class Connected(room: Room) : RoomEvent(room)
+    class Disconnected(room: Room) : RoomEvent(room)
+    class ConnectFailure(room: Room) : RoomEvent(room)
+    class ParticipantConnected(room: Room, val remoteParticipant: RemoteParticipant) : RoomEvent(room)
+    class ParticipantDisconnected(room: Room, val remoteParticipant: RemoteParticipant) : RoomEvent(room)
+    class DominantSpeakerChanged(room: Room, val remoteParticipant: RemoteParticipant?) : RoomEvent(room)
 }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomEvent.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomEvent.kt
@@ -4,6 +4,7 @@ import com.twilio.video.RemoteParticipant
 import com.twilio.video.Room
 
 sealed class RoomEvent {
+    data class Connecting(val room: Room) : RoomEvent()
     data class Connected(val room: Room) : RoomEvent()
     data class Disconnected(val room: Room) : RoomEvent()
     data class ConnectFailure(val room: Room) : RoomEvent()

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomEvent.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomEvent.kt
@@ -5,8 +5,7 @@ import com.twilio.video.Room
 
 sealed class RoomEvent(val room: Room) {
     class Connecting(room: Room) : RoomEvent(room)
-    class Connected(room: Room) : RoomEvent(room)
-    class Disconnected(room: Room) : RoomEvent(room)
+    class RoomState(room: Room) : RoomEvent(room)
     class ConnectFailure(room: Room) : RoomEvent(room)
     class ParticipantConnected(room: Room, val remoteParticipant: RemoteParticipant) : RoomEvent(room)
     class ParticipantDisconnected(room: Room, val remoteParticipant: RemoteParticipant) : RoomEvent(room)

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -23,7 +23,7 @@ class RoomManager : Room.Listener {
 
     val viewEvents: LiveData<RoomEvent?> = mutableViewEvents
 
-    val roomConnectionObserver = object: SingleObserver<Room> {
+    val roomConnectionObserver = object : SingleObserver<Room> {
         override fun onSuccess(room: Room) {
             this@RoomManager.run {
                 this.room = room
@@ -40,6 +40,8 @@ class RoomManager : Room.Listener {
     }
 
     override fun onConnected(room: Room) {
+        Timber.i("onConnected -> room sid: %s",
+                room.sid)
         mutableViewEvents.value = Connected(room)
     }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -1,35 +1,94 @@
 package com.twilio.video.app.ui.room
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.twilio.video.RemoteParticipant
 import com.twilio.video.Room
 import com.twilio.video.TwilioException
+import com.twilio.video.app.ui.room.RoomEvent.ConnectFailure
+import com.twilio.video.app.ui.room.RoomEvent.Connected
+import com.twilio.video.app.ui.room.RoomEvent.Disconnected
+import com.twilio.video.app.ui.room.RoomEvent.DominantSpeakerChanged
+import com.twilio.video.app.ui.room.RoomEvent.ParticipantConnected
+import com.twilio.video.app.ui.room.RoomEvent.ParticipantDisconnected
+import io.reactivex.SingleObserver
+import io.reactivex.disposables.Disposable
+import timber.log.Timber
 
 class RoomManager : Room.Listener {
 
-    override fun onRecordingStopped(room: Room) {
-    }
+    val roomConnectionObserver = RoomConnectionObserver()
 
-    override fun onParticipantDisconnected(room: Room, remoteParticipant: RemoteParticipant) {
-    }
+    private var room: Room? = null
+    private val mutableViewEvents: MutableLiveData<RoomEvent?> = MutableLiveData()
 
-    override fun onRecordingStarted(room: Room) {
-    }
-
-    override fun onConnectFailure(room: Room, twilioException: TwilioException) {
-    }
-
-    override fun onReconnected(room: Room) {
-    }
-
-    override fun onParticipantConnected(room: Room, remoteParticipant: RemoteParticipant) {
-    }
+    val viewEvents: LiveData<RoomEvent?> = mutableViewEvents
 
     override fun onConnected(room: Room) {
+        mutableViewEvents.value = Connected(room)
     }
 
     override fun onDisconnected(room: Room, twilioException: TwilioException?) {
+        Timber.i("Disconnected from room -> sid: %s, state: %s",
+                room.sid, room.state)
+        mutableViewEvents.value = Disconnected(room)
+    }
+
+    override fun onConnectFailure(room: Room, twilioException: TwilioException) {
+        Timber.e(
+                "Failed to connect to room -> sid: %s, state: %s, code: %d, error: %s",
+                room.sid,
+                room.state,
+                twilioException.code,
+                twilioException.message)
+        mutableViewEvents.value = ConnectFailure(room)
+    }
+
+    override fun onParticipantConnected(room: Room, remoteParticipant: RemoteParticipant) {
+        Timber.i("RemoteParticipant connected -> room sid: %s, remoteParticipant: %s",
+                room.sid, remoteParticipant.sid)
+        mutableViewEvents.value = ParticipantConnected(room, remoteParticipant)
+    }
+
+    override fun onParticipantDisconnected(room: Room, remoteParticipant: RemoteParticipant) {
+        Timber.i("RemoteParticipant disconnected -> room sid: %s, remoteParticipant: %s",
+                room.sid, remoteParticipant.sid)
+        mutableViewEvents.value = ParticipantDisconnected(room, remoteParticipant)
+    }
+
+    override fun onDominantSpeakerChanged(room: Room, remoteParticipant: RemoteParticipant?) {
+        Timber.i("DominantSpeakerChanged -> room sid: %s, remoteParticipant: %s",
+                room.sid, remoteParticipant?.sid)
+        mutableViewEvents.value = DominantSpeakerChanged(room, remoteParticipant)
+    }
+
+    override fun onRecordingStarted(room: Room) {}
+
+    override fun onReconnected(room: Room) {
+        Timber.i("onReconnected: %s", room.name)
     }
 
     override fun onReconnecting(room: Room, twilioException: TwilioException) {
+        Timber.i("onReconnecting: %s", room.name)
+    }
+
+    override fun onRecordingStopped(room: Room) {}
+
+    inner class RoomConnectionObserver : SingleObserver<Room> {
+
+        override fun onSubscribe(disposable: Disposable) {}
+
+        override fun onSuccess(room: Room) {
+            this@RoomManager.room = room
+//            updateUi(room)
+        }
+
+        override fun onError(e: Throwable) {
+            val message = "Failed to retrieve access token"
+            Timber.e("%s -> reason: %s", message, e.message)
+//            Snackbar.make(primaryVideoView, message, Snackbar.LENGTH_LONG)
+//                    .show()
+//            connect.setEnabled(true)
+        }
     }
 }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -15,7 +15,7 @@ import io.reactivex.SingleObserver
 import io.reactivex.disposables.Disposable
 import timber.log.Timber
 
-class RoomManager : Room.Listener {
+class RoomManager {
 
     private var room: Room? = null
     private val mutableViewEvents: MutableLiveData<RoomEvent?> = MutableLiveData()
@@ -38,59 +38,63 @@ class RoomManager : Room.Listener {
         }
     }
 
-    override fun onConnected(room: Room) {
-        Timber.i("onConnected -> room sid: %s",
-                room.sid)
-        mutableViewEvents.value = RoomState(room)
-    }
-
-    override fun onDisconnected(room: Room, twilioException: TwilioException?) {
-        Timber.i("Disconnected from room -> sid: %s, state: %s",
-                room.sid, room.state)
-        mutableViewEvents.value = RoomState(room)
-    }
-
-    override fun onConnectFailure(room: Room, twilioException: TwilioException) {
-        Timber.e(
-                "Failed to connect to room -> sid: %s, state: %s, code: %d, error: %s",
-                room.sid,
-                room.state,
-                twilioException.code,
-                twilioException.message)
-        mutableViewEvents.value = ConnectFailure(room)
-    }
-
-    override fun onParticipantConnected(room: Room, remoteParticipant: RemoteParticipant) {
-        Timber.i("RemoteParticipant connected -> room sid: %s, remoteParticipant: %s",
-                room.sid, remoteParticipant.sid)
-        mutableViewEvents.value = ParticipantConnected(room, remoteParticipant)
-    }
-
-    override fun onParticipantDisconnected(room: Room, remoteParticipant: RemoteParticipant) {
-        Timber.i("RemoteParticipant disconnected -> room sid: %s, remoteParticipant: %s",
-                room.sid, remoteParticipant.sid)
-        mutableViewEvents.value = ParticipantDisconnected(room, remoteParticipant)
-    }
-
-    override fun onDominantSpeakerChanged(room: Room, remoteParticipant: RemoteParticipant?) {
-        Timber.i("DominantSpeakerChanged -> room sid: %s, remoteParticipant: %s",
-                room.sid, remoteParticipant?.sid)
-        mutableViewEvents.value = DominantSpeakerChanged(room, remoteParticipant)
-    }
-
-    override fun onRecordingStarted(room: Room) {}
-
-    override fun onReconnected(room: Room) {
-        Timber.i("onReconnected: %s", room.name)
-    }
-
-    override fun onReconnecting(room: Room, twilioException: TwilioException) {
-        Timber.i("onReconnecting: %s", room.name)
-    }
-
-    override fun onRecordingStopped(room: Room) {}
+    val roomListener = RoomListener()
 
     fun disconnect() {
         room?.disconnect()
+    }
+
+    inner class RoomListener : Room.Listener {
+        override fun onConnected(room: Room) {
+            Timber.i("onConnected -> room sid: %s",
+                    room.sid)
+            mutableViewEvents.value = RoomState(room)
+        }
+
+        override fun onDisconnected(room: Room, twilioException: TwilioException?) {
+            Timber.i("Disconnected from room -> sid: %s, state: %s",
+                    room.sid, room.state)
+            mutableViewEvents.value = RoomState(room)
+        }
+
+        override fun onConnectFailure(room: Room, twilioException: TwilioException) {
+            Timber.e(
+                    "Failed to connect to room -> sid: %s, state: %s, code: %d, error: %s",
+                    room.sid,
+                    room.state,
+                    twilioException.code,
+                    twilioException.message)
+            mutableViewEvents.value = ConnectFailure(room)
+        }
+
+        override fun onParticipantConnected(room: Room, remoteParticipant: RemoteParticipant) {
+            Timber.i("RemoteParticipant connected -> room sid: %s, remoteParticipant: %s",
+                    room.sid, remoteParticipant.sid)
+            mutableViewEvents.value = ParticipantConnected(room, remoteParticipant)
+        }
+
+        override fun onParticipantDisconnected(room: Room, remoteParticipant: RemoteParticipant) {
+            Timber.i("RemoteParticipant disconnected -> room sid: %s, remoteParticipant: %s",
+                    room.sid, remoteParticipant.sid)
+            mutableViewEvents.value = ParticipantDisconnected(room, remoteParticipant)
+        }
+
+        override fun onDominantSpeakerChanged(room: Room, remoteParticipant: RemoteParticipant?) {
+            Timber.i("DominantSpeakerChanged -> room sid: %s, remoteParticipant: %s",
+                    room.sid, remoteParticipant?.sid)
+            mutableViewEvents.value = DominantSpeakerChanged(room, remoteParticipant)
+        }
+
+        override fun onRecordingStarted(room: Room) {}
+
+        override fun onReconnected(room: Room) {
+            Timber.i("onReconnected: %s", room.name)
+        }
+
+        override fun onReconnecting(room: Room, twilioException: TwilioException) {
+            Timber.i("onReconnecting: %s", room.name)
+        }
+
+        override fun onRecordingStopped(room: Room) {}
     }
 }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -6,12 +6,11 @@ import com.twilio.video.RemoteParticipant
 import com.twilio.video.Room
 import com.twilio.video.TwilioException
 import com.twilio.video.app.ui.room.RoomEvent.ConnectFailure
-import com.twilio.video.app.ui.room.RoomEvent.Connected
 import com.twilio.video.app.ui.room.RoomEvent.Connecting
-import com.twilio.video.app.ui.room.RoomEvent.Disconnected
 import com.twilio.video.app.ui.room.RoomEvent.DominantSpeakerChanged
 import com.twilio.video.app.ui.room.RoomEvent.ParticipantConnected
 import com.twilio.video.app.ui.room.RoomEvent.ParticipantDisconnected
+import com.twilio.video.app.ui.room.RoomEvent.RoomState
 import io.reactivex.SingleObserver
 import io.reactivex.disposables.Disposable
 import timber.log.Timber
@@ -42,13 +41,13 @@ class RoomManager : Room.Listener {
     override fun onConnected(room: Room) {
         Timber.i("onConnected -> room sid: %s",
                 room.sid)
-        mutableViewEvents.value = Connected(room)
+        mutableViewEvents.value = RoomState(room)
     }
 
     override fun onDisconnected(room: Room, twilioException: TwilioException?) {
         Timber.i("Disconnected from room -> sid: %s, state: %s",
                 room.sid, room.state)
-        mutableViewEvents.value = Disconnected(room)
+        mutableViewEvents.value = RoomState(room)
     }
 
     override fun onConnectFailure(room: Room, twilioException: TwilioException) {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -88,4 +88,8 @@ class RoomManager : Room.Listener {
     }
 
     override fun onRecordingStopped(room: Room) {}
+
+    fun disconnect() {
+        room?.disconnect()
+    }
 }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -18,12 +18,26 @@ import timber.log.Timber
 
 class RoomManager : Room.Listener {
 
-    val roomConnectionObserver = RoomConnectionObserver()
-
     private var room: Room? = null
     private val mutableViewEvents: MutableLiveData<RoomEvent?> = MutableLiveData()
 
     val viewEvents: LiveData<RoomEvent?> = mutableViewEvents
+
+    val roomConnectionObserver = object: SingleObserver<Room> {
+        override fun onSuccess(room: Room) {
+            this@RoomManager.run {
+                this.room = room
+                mutableViewEvents.value = Connecting(room)
+            }
+        }
+
+        override fun onError(e: Throwable) {
+            Timber.e("%s -> reason: %s", "Failed to retrieve access token", e.message)
+        }
+
+        override fun onSubscribe(d: Disposable) {
+        }
+    }
 
     override fun onConnected(room: Room) {
         mutableViewEvents.value = Connected(room)
@@ -74,24 +88,4 @@ class RoomManager : Room.Listener {
     }
 
     override fun onRecordingStopped(room: Room) {}
-
-    inner class RoomConnectionObserver : SingleObserver<Room> {
-
-        override fun onSubscribe(disposable: Disposable) {}
-
-        override fun onSuccess(room: Room) {
-            this@RoomManager.run {
-                this.room = room
-                mutableViewEvents.value = Connecting(room)
-            }
-        }
-
-        override fun onError(e: Throwable) {
-            val message = "Failed to retrieve access token"
-            Timber.e("%s -> reason: %s", message, e.message)
-//            Snackbar.make(primaryVideoView, message, Snackbar.LENGTH_LONG)
-//                    .show()
-//            connect.setEnabled(true)
-        }
-    }
 }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -7,6 +7,7 @@ import com.twilio.video.Room
 import com.twilio.video.TwilioException
 import com.twilio.video.app.ui.room.RoomEvent.ConnectFailure
 import com.twilio.video.app.ui.room.RoomEvent.Connected
+import com.twilio.video.app.ui.room.RoomEvent.Connecting
 import com.twilio.video.app.ui.room.RoomEvent.Disconnected
 import com.twilio.video.app.ui.room.RoomEvent.DominantSpeakerChanged
 import com.twilio.video.app.ui.room.RoomEvent.ParticipantConnected
@@ -79,8 +80,10 @@ class RoomManager : Room.Listener {
         override fun onSubscribe(disposable: Disposable) {}
 
         override fun onSuccess(room: Room) {
-            this@RoomManager.room = room
-//            updateUi(room)
+            this@RoomManager.run {
+                this.room = room
+                mutableViewEvents.value = Connecting(room)
+            }
         }
 
         override fun onError(e: Throwable) {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManagerModule.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManagerModule.kt
@@ -2,15 +2,11 @@ package com.twilio.video.app.ui.room
 
 import com.twilio.video.app.ApplicationModule
 import com.twilio.video.app.ApplicationScope
-import com.twilio.video.app.data.DataModule
-import com.twilio.video.app.data.api.VideoAppServiceModule
 import dagger.Module
 import dagger.Provides
 
 @Module(includes = [
-    ApplicationModule::class,
-    DataModule::class,
-    VideoAppServiceModule::class])
+    ApplicationModule::class])
 class RoomManagerModule {
 
     @Provides

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManagerModule.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManagerModule.kt
@@ -1,6 +1,7 @@
 package com.twilio.video.app.ui.room
 
 import com.twilio.video.app.ApplicationModule
+import com.twilio.video.app.ApplicationScope
 import com.twilio.video.app.data.DataModule
 import com.twilio.video.app.data.api.VideoAppServiceModule
 import dagger.Module
@@ -13,6 +14,7 @@ import dagger.Provides
 class RoomManagerModule {
 
     @Provides
+    @ApplicationScope
     fun providesRoomManager(): RoomManager {
         return RoomManager()
     }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManagerModule.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManagerModule.kt
@@ -1,0 +1,21 @@
+package com.twilio.video.app.ui.room
+
+import com.twilio.video.app.ApplicationModule
+import com.twilio.video.app.ApplicationScope
+import com.twilio.video.app.data.DataModule
+import com.twilio.video.app.data.api.VideoAppServiceModule
+import dagger.Module
+import dagger.Provides
+
+@Module(includes = [
+    ApplicationModule::class,
+    DataModule::class,
+    VideoAppServiceModule::class])
+class RoomManagerModule {
+
+    @Provides
+    @ApplicationScope
+    fun providesRoomManager(): RoomManager {
+        return RoomManager()
+    }
+}

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManagerModule.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManagerModule.kt
@@ -14,7 +14,6 @@ import dagger.Provides
 class RoomManagerModule {
 
     @Provides
-    @ApplicationScope
     fun providesRoomManager(): RoomManager {
         return RoomManager()
     }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManagerModule.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManagerModule.kt
@@ -1,7 +1,6 @@
 package com.twilio.video.app.ui.room
 
 import com.twilio.video.app.ApplicationModule
-import com.twilio.video.app.ApplicationScope
 import com.twilio.video.app.data.DataModule
 import com.twilio.video.app.data.api.VideoAppServiceModule
 import dagger.Module

--- a/app/src/main/java/com/twilio/video/app/ui/room/VideoServiceModule.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/VideoServiceModule.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2019 Twilio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twilio.video.app.ui.room;
+
+import com.twilio.video.app.VideoService;
+
+import dagger.Binds;
+import dagger.Module;
+import dagger.android.AndroidInjector;
+import dagger.multibindings.ClassKey;
+import dagger.multibindings.IntoMap;
+
+@Module(subcomponents = VideoServiceSubcomponent.class)
+public abstract class VideoServiceModule {
+
+    @Binds
+    @IntoMap
+    @ClassKey(VideoService.class)
+    abstract AndroidInjector.Factory<?> bindYourServiceInjectorFactory(
+            VideoServiceSubcomponent.Factory factory);
+}

--- a/app/src/main/java/com/twilio/video/app/ui/room/VideoServiceModule.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/VideoServiceModule.java
@@ -17,7 +17,6 @@
 package com.twilio.video.app.ui.room;
 
 import com.twilio.video.app.VideoService;
-
 import dagger.Binds;
 import dagger.Module;
 import dagger.android.AndroidInjector;

--- a/app/src/main/java/com/twilio/video/app/ui/room/VideoServiceSubcomponent.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/VideoServiceSubcomponent.java
@@ -17,7 +17,6 @@
 package com.twilio.video.app.ui.room;
 
 import com.twilio.video.app.VideoService;
-
 import dagger.Subcomponent;
 import dagger.android.AndroidInjector;
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/VideoServiceSubcomponent.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/VideoServiceSubcomponent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 Twilio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twilio.video.app.ui.room;
+
+import com.twilio.video.app.VideoService;
+
+import dagger.Subcomponent;
+import dagger.android.AndroidInjector;
+
+@Subcomponent
+public interface VideoServiceSubcomponent extends AndroidInjector<VideoService> {
+    @Subcomponent.Factory
+    interface Factory extends AndroidInjector.Factory<VideoService> {}
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,10 @@
     <string name="login_screen_auth_error_title">Login Error</string>
     <string name="login_screen_auth_error_desc">There was an issue logging in.</string>
 
+    <!--  Room Screen  -->
+    <string name="room_screen_connection_failure_title">Connection Failure</string>
+    <string name="room_screen_connection_failure_message">Failed to connect to the room.</string>
+
     <!--  Notifications  -->
     <string name="video_chat_notification_channel_title">Video Chat</string>
     <string name="video_chat_notification_message">Live video chat in progress.</string>

--- a/app/src/twilio/java/com/twilio/video/app/VideoApplicationComponent.java
+++ b/app/src/twilio/java/com/twilio/video/app/VideoApplicationComponent.java
@@ -7,6 +7,7 @@ import com.twilio.video.app.ui.ScreenSelectorModule;
 import com.twilio.video.app.ui.login.LoginActivityModule;
 import com.twilio.video.app.ui.room.RoomActivityModule;
 import com.twilio.video.app.ui.room.RoomManagerModule;
+import com.twilio.video.app.ui.room.VideoServiceModule;
 import com.twilio.video.app.ui.settings.SettingsActivityModule;
 import com.twilio.video.app.ui.settings.SettingsFragmentModule;
 import com.twilio.video.app.ui.splash.SplashActivityModule;

--- a/app/src/twilio/java/com/twilio/video/app/VideoApplicationComponent.java
+++ b/app/src/twilio/java/com/twilio/video/app/VideoApplicationComponent.java
@@ -6,6 +6,7 @@ import com.twilio.video.app.data.api.VideoAppServiceModule;
 import com.twilio.video.app.ui.ScreenSelectorModule;
 import com.twilio.video.app.ui.login.LoginActivityModule;
 import com.twilio.video.app.ui.room.RoomActivityModule;
+import com.twilio.video.app.ui.room.RoomManagerModule;
 import com.twilio.video.app.ui.settings.SettingsActivityModule;
 import com.twilio.video.app.ui.settings.SettingsFragmentModule;
 import com.twilio.video.app.ui.splash.SplashActivityModule;
@@ -26,7 +27,8 @@ import dagger.android.AndroidInjectionModule;
         LoginActivityModule.class,
         RoomActivityModule.class,
         SettingsActivityModule.class,
-        SettingsFragmentModule.class
+        SettingsFragmentModule.class,
+        RoomManagerModule.class
     }
 )
 public interface VideoApplicationComponent {

--- a/app/src/twilio/java/com/twilio/video/app/VideoApplicationComponent.java
+++ b/app/src/twilio/java/com/twilio/video/app/VideoApplicationComponent.java
@@ -28,6 +28,7 @@ import dagger.android.AndroidInjectionModule;
         RoomActivityModule.class,
         SettingsActivityModule.class,
         SettingsFragmentModule.class,
+        VideoServiceModule.class,
         RoomManagerModule.class
     }
 )


### PR DESCRIPTION
## Description

Abstracted room state management from RoomActivity so the activity and VideoService can subscribe to room state. Audio and screen sharing now works in the background even if the RoomActivity has been destroyed.

## Breakdown

- Created RoomManager to handle and emit room state to subscribers.
- Remove room management from RoomActivity.
- Made changes to RoomActivity to support configuration changes.
- Finish implementation of VideoService.
- Foreground service can be clicked to be taken back to the room.

## Validation

- Manually tested against two physical Android devices to avoid regressions.

## Additional Notes

There are still a few bugs when performing config changes on the activity, but the activity can be killed and the participant will still publish audio and screen sharing tracks in the background.

## Submission Checklist

 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
