### PR TITLE
Fix p2p default topology bug

### DIFF
--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/PreferencesTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/PreferencesTest.kt
@@ -1,0 +1,41 @@
+package com.twilio.video.app.e2eTest
+
+import android.preference.PreferenceManager
+import androidx.test.ext.junit.rules.activityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.twilio.video.app.data.Preferences
+import com.twilio.video.app.data.api.model.Topology
+import com.twilio.video.app.screen.assertSettingsTitleIsVisible
+import com.twilio.video.app.screen.clickSettingsMenuItem
+import com.twilio.video.app.ui.splash.SplashActivity
+import com.twilio.video.app.util.getTargetContext
+import com.twilio.video.app.util.retryEspressoAction
+import com.twilio.video.app.util.uiDevice
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class PreferencesTest : BaseUITest() {
+
+    @get:Rule
+    var scenario = activityScenarioRule<SplashActivity>()
+
+    @Test
+    fun it_should_assert_correct_default_shared_preferences() {
+        retryEspressoAction { clickSettingsMenuItem() }
+
+        retryEspressoAction { assertSettingsTitleIsVisible() }
+
+        uiDevice().run {
+            pressBack()
+        }
+
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getTargetContext())
+        assertThat(sharedPreferences.getString(Preferences.TOPOLOGY, null), equalTo(Topology.GROUP.string))
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,9 +56,9 @@
     </string-array>
 
     <string-array name="settings_screen_topology_array">
-        <item>peer-to-peer</item>
         <item>group</item>
         <item>group-small</item>
+        <item>peer-to-peer</item>
     </string-array>
     <string-array name="settings_screen_aspect_ratio_array">
         <item>4:3</item>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -38,7 +38,7 @@
             android:title="@string/settings_screen_environment_string"
             android:negativeButtonText="@null"/>
         <ListPreference
-            android:defaultValue="peer-to-peer"
+            android:defaultValue="group"
             android:entries="@array/settings_screen_topology_array"
             android:entryValues="@array/settings_screen_topology_array"
             android:key="pref_topology"


### PR DESCRIPTION
## Description

Fixed bug where default topology would be set to P2P when navigating to the settings screen.

## Breakdown

- Change default value to group in preferences.xml

## Validation

- Manual tested.
- Passed CI pipeline.

## Additional Notes

N/A

## Submission Checklist

 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
