### PR TITLE
Introduce Coroutines and Viewmodel

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -173,7 +173,6 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"
-    implementation "com.jakewharton.retrofit:retrofit2-rxjava2-adapter:1.0.0"
 
     internalImplementation "com.microsoft.appcenter:appcenter-distribute:2.5.1"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     def daggerVersion = '2.25.4'
     def daggerAndroidProcessor = "com.google.dagger:dagger-android-processor:$daggerVersion"
     def daggerCompiler = "com.google.dagger:dagger-compiler:$daggerVersion"
-    def retrofitVersion = '2.1.0'
+    def retrofitVersion = '2.6.4'
     def espressoVersion = '3.2.0'
     def espresso = "androidx.test.espresso:espresso-core:$espressoVersion"
     def androidXTest = '1.2.0'
@@ -156,6 +156,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-service:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata:$lifecycleVersion"
     implementation "androidx.fragment:fragment:1.2.2"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation "com.appyvet:materialrangebar:1.3"
     implementation "com.jakewharton:butterknife:$butterknifeVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,10 +144,10 @@ dependencies {
     def testCore = "androidx.test:core:$androidXTest"
     def junitExtensions = 'androidx.test.ext:junit-ktx:1.1.1'
     def lifecycleVersion = '2.2.0'
-    def coroutines_android_version = '1.3.3'
+    def coroutinesAndroidVersion = '1.3.3'
 
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_android_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_android_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesAndroidVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesAndroidVersion"
     implementation 'com.twilio:twilio-android-env:1.0.0'
     implementation videoAndroidSdkDep
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
@@ -184,6 +184,7 @@ dependencies {
     testImplementation testCore
     testImplementation espresso
     testImplementation junitExtensions
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesAndroidVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation 'org.robolectric:robolectric:4.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,7 +144,10 @@ dependencies {
     def testCore = "androidx.test:core:$androidXTest"
     def junitExtensions = 'androidx.test.ext:junit-ktx:1.1.1'
     def lifecycleVersion = '2.2.0'
+    def coroutines_android_version = '1.3.3'
 
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_android_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_android_version"
     implementation 'com.twilio:twilio-android-env:1.0.0'
     implementation videoAndroidSdkDep
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"

--- a/app/src/community/java/com/twilio/video/app/VideoApplicationComponent.java
+++ b/app/src/community/java/com/twilio/video/app/VideoApplicationComponent.java
@@ -20,8 +20,8 @@ import com.twilio.video.app.auth.CommunityAuthModule;
 import com.twilio.video.app.data.CommunityDataModule;
 import com.twilio.video.app.ui.CommunityScreenSelectorModule;
 import com.twilio.video.app.ui.login.CommunityLoginActivityModule;
+import com.twilio.video.app.ui.room.CommunityRoomManagerModule;
 import com.twilio.video.app.ui.room.RoomActivityModule;
-import com.twilio.video.app.ui.room.RoomManagerModule;
 import com.twilio.video.app.ui.room.VideoServiceModule;
 import com.twilio.video.app.ui.settings.SettingsActivityModule;
 import com.twilio.video.app.ui.settings.SettingsFragmentModule;
@@ -44,7 +44,7 @@ import dagger.android.AndroidInjectionModule;
         SettingsActivityModule.class,
         SettingsFragmentModule.class,
         VideoServiceModule.class,
-        RoomManagerModule.class
+        CommunityRoomManagerModule.class
     }
 )
 public interface VideoApplicationComponent {

--- a/app/src/community/java/com/twilio/video/app/data/CommunityTokenService.kt
+++ b/app/src/community/java/com/twilio/video/app/data/CommunityTokenService.kt
@@ -13,21 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.twilio.video.app.data
 
-package com.twilio.video.app.data;
+import com.twilio.video.app.BuildConfig
+import com.twilio.video.app.data.api.TokenService
+import com.twilio.video.app.data.api.model.RoomProperties
 
-import com.twilio.video.app.BuildConfig;
-import com.twilio.video.app.data.api.TokenService;
-import com.twilio.video.app.data.api.model.RoomProperties;
-import io.reactivex.Single;
-
-public class CommunityTokenService implements TokenService {
+class CommunityTokenService : TokenService {
     /*
      * TODO: Topology is ignored so the Room will be the default type setup for the account. Use
      * REST API to create a Room with topology and create token with Room SID.
      */
-    @Override
-    public Single<String> getToken(final String identity, final RoomProperties roomProperties) {
-        return Single.fromCallable(() -> BuildConfig.TWILIO_ACCESS_TOKEN);
+    override suspend fun getToken(identity: String, roomProperties: RoomProperties): String {
+        return BuildConfig.TWILIO_ACCESS_TOKEN
     }
 }

--- a/app/src/community/java/com/twilio/video/app/ui/room/CommunityRoomManagerModule.kt
+++ b/app/src/community/java/com/twilio/video/app/ui/room/CommunityRoomManagerModule.kt
@@ -1,0 +1,28 @@
+package com.twilio.video.app.ui.room
+
+import android.app.Application
+import android.content.SharedPreferences
+import com.twilio.video.app.ApplicationModule
+import com.twilio.video.app.ApplicationScope
+import com.twilio.video.app.data.CommunityDataModule
+import com.twilio.video.app.data.DataModule
+import com.twilio.video.app.data.api.TokenService
+import dagger.Module
+import dagger.Provides
+
+@Module(includes = [
+    ApplicationModule::class,
+    DataModule::class,
+    CommunityDataModule::class])
+class CommunityRoomManagerModule {
+
+    @Provides
+    @ApplicationScope
+    fun providesRoomManager(
+        application: Application,
+        sharedPreferences: SharedPreferences,
+        tokenService: TokenService
+    ): RoomManager {
+        return RoomManager(application, sharedPreferences, tokenService)
+    }
+}

--- a/app/src/main/java/com/twilio/video/app/data/api/TokenService.kt
+++ b/app/src/main/java/com/twilio/video/app/data/api/TokenService.kt
@@ -17,7 +17,6 @@
 package com.twilio.video.app.data.api
 
 import com.twilio.video.app.data.api.model.RoomProperties
-import io.reactivex.Single
 
 interface TokenService {
     suspend fun getToken(identity: String, roomProperties: RoomProperties): String

--- a/app/src/main/java/com/twilio/video/app/data/api/TokenService.kt
+++ b/app/src/main/java/com/twilio/video/app/data/api/TokenService.kt
@@ -20,5 +20,5 @@ import com.twilio.video.app.data.api.model.RoomProperties
 import io.reactivex.Single
 
 interface TokenService {
-    fun getToken(identity: String, roomProperties: RoomProperties): Single<String>
+    suspend fun getToken(identity: String, roomProperties: RoomProperties): String
 }

--- a/app/src/main/java/com/twilio/video/app/data/api/VideoAppService.kt
+++ b/app/src/main/java/com/twilio/video/app/data/api/VideoAppService.kt
@@ -13,19 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.twilio.video.app.data.api
 
-package com.twilio.video.app.data.api;
+import retrofit2.http.GET
+import retrofit2.http.Query
 
-import io.reactivex.Single;
-import retrofit2.http.GET;
-import retrofit2.http.Query;
-
-public interface VideoAppService {
+interface VideoAppService {
     @GET("api/v1/token")
-    Single<String> getToken(
-            @Query("identity") String identity,
-            @Query("roomName") String roomName,
-            @Query("appEnvironment") String appEnvironment,
-            @Query("topology") String topology,
-            @Query("recordParticipantsOnConnect") boolean recordParticipantsOnConnect);
+    suspend fun getToken(
+            @Query("identity") identity: String?,
+            @Query("roomName") roomName: String?,
+            @Query("appEnvironment") appEnvironment: String?,
+            @Query("topology") topology: String?,
+            @Query("recordParticipantsOnConnect") recordParticipantsOnConnect: Boolean): String
 }

--- a/app/src/main/java/com/twilio/video/app/data/api/VideoAppService.kt
+++ b/app/src/main/java/com/twilio/video/app/data/api/VideoAppService.kt
@@ -21,9 +21,10 @@ import retrofit2.http.Query
 interface VideoAppService {
     @GET("api/v1/token")
     suspend fun getToken(
-            @Query("identity") identity: String?,
-            @Query("roomName") roomName: String?,
-            @Query("appEnvironment") appEnvironment: String?,
-            @Query("topology") topology: String?,
-            @Query("recordParticipantsOnConnect") recordParticipantsOnConnect: Boolean): String
+        @Query("identity") identity: String?,
+        @Query("roomName") roomName: String?,
+        @Query("appEnvironment") appEnvironment: String?,
+        @Query("topology") topology: String?,
+        @Query("recordParticipantsOnConnect") recordParticipantsOnConnect: Boolean
+    ): String
 }

--- a/app/src/main/java/com/twilio/video/app/data/api/VideoAppServiceDelegate.kt
+++ b/app/src/main/java/com/twilio/video/app/data/api/VideoAppServiceDelegate.kt
@@ -29,7 +29,7 @@ class VideoAppServiceDelegate(
     private val videoAppServiceProd: VideoAppService
 ) : TokenService {
 
-    override fun getToken(identity: String, roomProperties: RoomProperties): Single<String> {
+    override suspend fun getToken(identity: String, roomProperties: RoomProperties): String {
         val env = sharedPreferences.getString(
                 Preferences.ENVIRONMENT, Preferences.ENVIRONMENT_DEFAULT)
 

--- a/app/src/main/java/com/twilio/video/app/data/api/VideoAppServiceDelegate.kt
+++ b/app/src/main/java/com/twilio/video/app/data/api/VideoAppServiceDelegate.kt
@@ -19,7 +19,6 @@ package com.twilio.video.app.data.api
 import android.content.SharedPreferences
 import com.twilio.video.app.data.Preferences
 import com.twilio.video.app.data.api.model.RoomProperties
-import io.reactivex.Single
 import timber.log.Timber
 
 class VideoAppServiceDelegate(

--- a/app/src/main/java/com/twilio/video/app/data/api/VideoAppServiceModule.java
+++ b/app/src/main/java/com/twilio/video/app/data/api/VideoAppServiceModule.java
@@ -17,11 +17,9 @@
 package com.twilio.video.app.data.api;
 
 import android.content.SharedPreferences;
-import com.jakewharton.retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import com.twilio.video.app.ApplicationScope;
 import dagger.Module;
 import dagger.Provides;
-import io.reactivex.schedulers.Schedulers;
 import javax.inject.Named;
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
@@ -50,8 +48,6 @@ public class VideoAppServiceModule {
         return new Retrofit.Builder()
                 .client(okHttpClient)
                 .baseUrl(VIDEO_APP_SERVICE_DEV_URL)
-                .addCallAdapterFactory(
-                        RxJava2CallAdapterFactory.createWithScheduler(Schedulers.io()))
                 .addConverterFactory(ScalarsConverterFactory.create())
                 .addConverterFactory(GsonConverterFactory.create())
                 .build()
@@ -66,8 +62,6 @@ public class VideoAppServiceModule {
         return new Retrofit.Builder()
                 .client(okHttpClient)
                 .baseUrl(VIDEO_APP_SERVICE_STAGE_URL)
-                .addCallAdapterFactory(
-                        RxJava2CallAdapterFactory.createWithScheduler(Schedulers.io()))
                 .addConverterFactory(ScalarsConverterFactory.create())
                 .addConverterFactory(GsonConverterFactory.create())
                 .build()
@@ -82,8 +76,6 @@ public class VideoAppServiceModule {
         return new Retrofit.Builder()
                 .client(okHttpClient)
                 .baseUrl(VIDEO_APP_SERVICE_PROD_URL)
-                .addCallAdapterFactory(
-                        RxJava2CallAdapterFactory.createWithScheduler(Schedulers.io()))
                 .addConverterFactory(ScalarsConverterFactory.create())
                 .addConverterFactory(GsonConverterFactory.create())
                 .build()

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -513,17 +513,18 @@ public class RoomActivity extends BaseActivity {
                                             Preferences.RECORD_PARTICIPANTS_ON_CONNECT,
                                             Preferences.RECORD_PARTICIPANTS_ON_CONNECT_DEFAULT))
                             .createRoomProperties();
+            updateEnv();
 
-            Single<Room> connection =
-                    updateEnv()
-                            .andThen(tokenService.getToken(displayName, roomProperties))
-                            .flatMap(token -> connect(token, roomName));
+            String token = viewModel.connectToRoom(roomProperties);
 
-            connection
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .doFinally(rxDisposables::clear)
-                    .doOnSubscribe(disposable -> InputUtils.hideKeyboard(this))
-                    .subscribe(roomManager.getRoomConnectionObserver());
+            InputUtils.hideKeyboard(this);
+
+//            connect(token, roomName);
+//            connection
+//                    .observeOn(AndroidSchedulers.mainThread())
+//                    .doFinally { rxDisposables.clear() }
+//                .doOnSubscribe { disposable: Disposable? -> InputUtils.hideKeyboard(this) }
+//                .subscribe(roomManager.roomConnectionObserver)
         }
     }
 
@@ -1069,19 +1070,16 @@ public class RoomActivity extends BaseActivity {
      * @return Completable
      */
     private Completable updateEnv() {
-        return Completable.fromAction(
-                () -> {
-                    String env =
-                            sharedPreferences.getString(
-                                    Preferences.ENVIRONMENT, Preferences.ENVIRONMENT_DEFAULT);
-                    String nativeEnvironmentVariableValue =
-                            EnvUtil.getNativeEnvironmentVariableValue(env);
-                    Env.set(
-                            RoomActivity.this,
-                            EnvUtil.TWILIO_ENV_KEY,
-                            nativeEnvironmentVariableValue,
-                            true);
-                });
+        String env =
+                sharedPreferences.getString(
+                        Preferences.ENVIRONMENT, Preferences.ENVIRONMENT_DEFAULT);
+        String nativeEnvironmentVariableValue =
+                EnvUtil.getNativeEnvironmentVariableValue(env);
+        Env.set(
+                RoomActivity.this,
+                EnvUtil.TWILIO_ENV_KEY,
+                nativeEnvironmentVariableValue,
+                true);
     }
 
     /**

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -285,7 +285,7 @@ public class RoomActivity extends BaseActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        RoomViewModelFactory factory = new RoomViewModelFactory(tokenService);
+        RoomViewModelFactory factory = new RoomViewModelFactory(this, tokenService, roomManager);
         roomViewModel = new ViewModelProvider(this, factory).get(RoomViewModel.class);
 
         if (savedInstanceState != null) {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -1271,7 +1271,6 @@ public class RoomActivity extends BaseActivity {
     }
 
     private void bindRoomEvents(RoomEvent roomEvent) {
-        Timber.d("Thread: %s", Thread.currentThread().getName());
         if (roomEvent != null) {
             this.room = roomEvent.getRoom();
             if (room != null) {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomEvent.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomEvent.kt
@@ -3,7 +3,8 @@ package com.twilio.video.app.ui.room
 import com.twilio.video.RemoteParticipant
 import com.twilio.video.Room
 
-sealed class RoomEvent(val room: Room) {
+sealed class RoomEvent(val room: Room? = null) {
+    object TokenError : RoomEvent()
     class Connecting(room: Room) : RoomEvent(room)
     class RoomState(room: Room) : RoomEvent(room)
     class ConnectFailure(room: Room) : RoomEvent(room)

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -33,6 +33,7 @@ import com.twilio.video.app.ui.room.RoomEvent.DominantSpeakerChanged
 import com.twilio.video.app.ui.room.RoomEvent.ParticipantConnected
 import com.twilio.video.app.ui.room.RoomEvent.ParticipantDisconnected
 import com.twilio.video.app.ui.room.RoomEvent.RoomState
+import com.twilio.video.app.ui.room.RoomEvent.TokenError
 import com.twilio.video.app.util.EnvUtil
 import timber.log.Timber
 
@@ -67,6 +68,7 @@ class RoomManager(
             tokenService.getToken(identity, roomProperties)
         } catch (e: Exception) {
             Timber.e(e, "Failed to retrieve token")
+            mutableViewEvents.value = TokenError
             return
         }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -17,26 +17,10 @@ import timber.log.Timber
 
 class RoomManager {
 
-    private var room: Room? = null
+    var room: Room? = null
     private val mutableViewEvents: MutableLiveData<RoomEvent?> = MutableLiveData()
 
     val viewEvents: LiveData<RoomEvent?> = mutableViewEvents
-
-    val roomConnectionObserver = object : SingleObserver<Room> {
-        override fun onSuccess(room: Room) {
-            this@RoomManager.run {
-                this.room = room
-                mutableViewEvents.value = Connecting(room)
-            }
-        }
-
-        override fun onError(e: Throwable) {
-            Timber.e("%s -> reason: %s", "Failed to retrieve access token", e.message)
-        }
-
-        override fun onSubscribe(d: Disposable) {
-        }
-    }
 
     val roomListener = RoomListener()
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManagerModule.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManagerModule.kt
@@ -1,17 +1,28 @@
 package com.twilio.video.app.ui.room
 
+import android.app.Application
+import android.content.SharedPreferences
 import com.twilio.video.app.ApplicationModule
 import com.twilio.video.app.ApplicationScope
+import com.twilio.video.app.data.DataModule
+import com.twilio.video.app.data.api.TokenService
+import com.twilio.video.app.data.api.VideoAppServiceModule
 import dagger.Module
 import dagger.Provides
 
 @Module(includes = [
-    ApplicationModule::class])
+    ApplicationModule::class,
+    DataModule::class,
+    VideoAppServiceModule::class])
 class RoomManagerModule {
 
     @Provides
     @ApplicationScope
-    fun providesRoomManager(): RoomManager {
-        return RoomManager()
+    fun providesRoomManager(
+        application: Application,
+        sharedPreferences: SharedPreferences,
+        tokenService: TokenService
+    ): RoomManager {
+        return RoomManager(application, sharedPreferences, tokenService)
     }
 }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -1,54 +1,44 @@
 package com.twilio.video.app.ui.room
 
-import android.content.Context
-import android.content.SharedPreferences
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.twilio.video.ConnectOptions
-import com.twilio.video.Video
-import com.twilio.video.app.data.api.TokenService
-import com.twilio.video.app.data.api.model.RoomProperties
+import com.twilio.video.LocalAudioTrack
+import com.twilio.video.LocalVideoTrack
 import kotlinx.coroutines.launch
 
-class RoomViewModel(private val context: Context,
-                    private val tokenService: TokenService,
-                    private val roomManager: RoomManager): ViewModel() {
+class RoomViewModel(private val roomManager: RoomManager) : ViewModel() {
 
-    // TODO Use a ViewState instead of RoomEvents
-    private val mutableRoomEvents = MutableLiveData<RoomEvent>()
+    // TODO Build ViewStates for UI to consume instead of just passing events
+    val roomEvents: LiveData<RoomEvent?> = roomManager.viewEvents
 
-    val roomEvents: LiveData<RoomEvent> = mutableRoomEvents
-    fun retrieveToken(roomProperties: RoomProperties, identity: String): String {
-        lateinit var token: String
+    // TODO Add single point of entry function from UI, something like "processInput"
+
+    fun connectToRoom(
+        identity: String,
+        roomName: String,
+        localAudioTracks: List<LocalAudioTrack>,
+        localVideoTracks: List<LocalVideoTrack>,
+        isNetworkQualityEnabled: Boolean
+    ) =
         viewModelScope.launch {
-            token = tokenService.getToken(identity, roomProperties)
-            Video.connect(
-                    context,
-                    connectOptions,
-                    roomManager.roomListener)
+            roomManager.connectToRoom(
+                    identity,
+                    roomName,
+                    localAudioTracks,
+                    localVideoTracks,
+                    isNetworkQualityEnabled)
         }
-        return token
+
+    fun disconnect() {
+        roomManager.disconnect()
     }
 
-    private suspend fun connectToRoom(context: Context,
-                                      token: String,
-                                      roomName: String,
-                                      sharedPreferences: SharedPreferences,
-                                      connectOptions: ConnectOptions) {
-
-    }
-
-    class RoomViewModelFactory(
-            private val context: Context
-            private val tokenService: TokenService,
-            private val roomManager: RoomManager): ViewModelProvider.Factory {
+    class RoomViewModelFactory(private val roomManager: RoomManager) : ViewModelProvider.Factory {
 
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return RoomViewModel(context, tokenService, roomManager) as T
+            return RoomViewModel(roomManager) as T
         }
-
     }
 }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -3,22 +3,19 @@ package com.twilio.video.app.ui.room
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.twilio.video.app.data.api.TokenService
 import com.twilio.video.app.data.api.model.RoomProperties
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-class RoomViewModel: ViewModel() {
-
-    // TODO Inject in constructor for easier unit testing
-    @Inject lateinit var tokenService: TokenService
+class RoomViewModel(private val tokenService: TokenService): ViewModel() {
 
     // TODO Use a ViewState instead of RoomEvents
     private val mutableRoomEvents = MutableLiveData<RoomEvent>()
-    val roomEvents: LiveData<RoomEvent> = mutableRoomEvents
 
-    fun connectToRoom(roomProperties: RoomProperties, identity: String): String {
+    val roomEvents: LiveData<RoomEvent> = mutableRoomEvents
+    fun retrieveToken(roomProperties: RoomProperties, identity: String): String {
         lateinit var token: String
         viewModelScope.launch {
             token = tokenService.getToken(identity, roomProperties)
@@ -26,6 +23,11 @@ class RoomViewModel: ViewModel() {
         return token
     }
 
-    fun connectToRoom() {
+    class RoomViewModelFactory(private val tokenService: TokenService): ViewModelProvider.Factory {
+
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return RoomViewModel(tokenService) as T
+        }
+
     }
 }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -1,0 +1,31 @@
+package com.twilio.video.app.ui.room
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.twilio.video.app.data.api.TokenService
+import com.twilio.video.app.data.api.model.RoomProperties
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class RoomViewModel: ViewModel() {
+
+    // TODO Inject in constructor for easier unit testing
+    @Inject lateinit var tokenService: TokenService
+
+    // TODO Use a ViewState instead of RoomEvents
+    private val mutableRoomEvents = MutableLiveData<RoomEvent>()
+    val roomEvents: LiveData<RoomEvent> = mutableRoomEvents
+
+    fun connectToRoom(roomProperties: RoomProperties, identity: String): String {
+        lateinit var token: String
+        viewModelScope.launch {
+            token = tokenService.getToken(identity, roomProperties)
+        }
+        return token
+    }
+
+    fun connectToRoom() {
+    }
+}

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -1,15 +1,21 @@
 package com.twilio.video.app.ui.room
 
+import android.content.Context
+import android.content.SharedPreferences
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.twilio.video.ConnectOptions
+import com.twilio.video.Video
 import com.twilio.video.app.data.api.TokenService
 import com.twilio.video.app.data.api.model.RoomProperties
 import kotlinx.coroutines.launch
 
-class RoomViewModel(private val tokenService: TokenService): ViewModel() {
+class RoomViewModel(private val context: Context,
+                    private val tokenService: TokenService,
+                    private val roomManager: RoomManager): ViewModel() {
 
     // TODO Use a ViewState instead of RoomEvents
     private val mutableRoomEvents = MutableLiveData<RoomEvent>()
@@ -19,14 +25,29 @@ class RoomViewModel(private val tokenService: TokenService): ViewModel() {
         lateinit var token: String
         viewModelScope.launch {
             token = tokenService.getToken(identity, roomProperties)
+            Video.connect(
+                    context,
+                    connectOptions,
+                    roomManager.roomListener)
         }
         return token
     }
 
-    class RoomViewModelFactory(private val tokenService: TokenService): ViewModelProvider.Factory {
+    private suspend fun connectToRoom(context: Context,
+                                      token: String,
+                                      roomName: String,
+                                      sharedPreferences: SharedPreferences,
+                                      connectOptions: ConnectOptions) {
+
+    }
+
+    class RoomViewModelFactory(
+            private val context: Context
+            private val tokenService: TokenService,
+            private val roomManager: RoomManager): ViewModelProvider.Factory {
 
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return RoomViewModel(tokenService) as T
+            return RoomViewModel(context, tokenService, roomManager) as T
         }
 
     }

--- a/app/src/main/java/com/twilio/video/app/ui/room/VideoService.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/VideoService.kt
@@ -51,14 +51,15 @@ class VideoService : LifecycleService() {
 
     private fun bindRoomEvents(nullableRoomEvent: RoomEvent?) {
         nullableRoomEvent?.let { roomEvent ->
-            val room = roomEvent.room
-            if (roomEvent is RoomState) {
-                if (room.state == CONNECTED) {
-                    val roomNotification = RoomNotification(this@VideoService)
-                    startForeground(
-                            ONGOING_NOTIFICATION_ID,
-                            roomNotification.buildNotification(room.name))
-                } else if (room.state == DISCONNECTED) stopSelf()
+            roomEvent.room?.let { room ->
+                if (roomEvent is RoomState) {
+                    if (room.state == CONNECTED) {
+                        val roomNotification = RoomNotification(this@VideoService)
+                        startForeground(
+                                ONGOING_NOTIFICATION_ID,
+                                roomNotification.buildNotification(room.name))
+                    } else if (room.state == DISCONNECTED) stopSelf()
+                }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <!--  Room Screen  -->
     <string name="room_screen_connection_failure_title">Connection Failure</string>
     <string name="room_screen_connection_failure_message">Failed to connect to the room.</string>
+    <string name="room_screen_token_retrieval_failure_message">Failed to retrieve the room token.</string>
 
     <!--  Notifications  -->
     <string name="room_notification_channel_title">Video Call</string>

--- a/app/src/test/java/com/twilio/video/app/data/api/VideoAppServiceDelegateTest.kt
+++ b/app/src/test/java/com/twilio/video/app/data/api/VideoAppServiceDelegateTest.kt
@@ -6,7 +6,11 @@ import com.nhaarman.mockitokotlin2.whenever
 import com.twilio.video.app.data.Preferences
 import com.twilio.video.app.data.api.model.RoomProperties
 import com.twilio.video.app.data.api.model.Topology
-import io.reactivex.Single
+import com.twilio.video.app.util.MainCoroutineScopeRule
+import kotlinx.coroutines.test.runBlockingTest
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Rule
 import org.junit.Test
 
 private const val identity = "John"
@@ -16,63 +20,77 @@ private const val prodTestToken = "ProdTestToken"
 
 class VideoAppServiceDelegateTest {
 
+    @get:Rule
+    val coroutineScope = MainCoroutineScopeRule()
+
     private val roomProperties = RoomProperties.Builder()
             .setName("room")
             .setTopology(Topology.fromString("group"))
             .setRecordOnParticipantsConnect(true)
             .createRoomProperties()
     private val sharedPreferences: SharedPreferences = mock()
-    private val videoAppServiceDev: VideoAppService = mock {
-        mockService(mock, devTestToken)
-    }
-    private val videoAppServiceStage: VideoAppService = mock {
-        mockService(mock, stageTestToken)
-    }
-    private val videoAppServiceProd: VideoAppService = mock {
-        mockService(mock, prodTestToken)
-    }
+    private lateinit var videoAppServiceDev: VideoAppService
+    private lateinit var videoAppServiceStage: VideoAppService
+    private lateinit var videoAppServiceProd: VideoAppService
 
     @Test
     fun `getToken should retrieve production environment token successfully`() {
-        val videoAppServiceDelegate = VideoAppServiceDelegate(sharedPreferences, videoAppServiceDev, videoAppServiceStage, videoAppServiceProd)
-        whenever(sharedPreferences.getString(Preferences.ENVIRONMENT, Preferences.ENVIRONMENT_DEFAULT))
-                .thenReturn("production")
+        coroutineScope.runBlockingTest {
+            setupMocks()
+            val videoAppServiceDelegate = VideoAppServiceDelegate(sharedPreferences, videoAppServiceDev, videoAppServiceStage, videoAppServiceProd)
+            whenever(sharedPreferences.getString(Preferences.ENVIRONMENT, Preferences.ENVIRONMENT_DEFAULT))
+                    .thenReturn("production")
 
-        val testObserver = videoAppServiceDelegate.getToken(identity, roomProperties).test()
-
-        testObserver.assertValue(prodTestToken)
+            val token = videoAppServiceDelegate.getToken(identity, roomProperties)
+            assertThat(token, equalTo(prodTestToken))
+        }
     }
 
     @Test
     fun `getToken should retrieve stage environment token successfully`() {
-        val videoAppServiceDelegate = VideoAppServiceDelegate(sharedPreferences, videoAppServiceDev, videoAppServiceStage, videoAppServiceProd)
-        whenever(sharedPreferences.getString(Preferences.ENVIRONMENT, Preferences.ENVIRONMENT_DEFAULT))
-                .thenReturn(TWILIO_API_STAGE_ENV)
+        coroutineScope.runBlockingTest {
+            setupMocks()
+            val videoAppServiceDelegate = VideoAppServiceDelegate(sharedPreferences, videoAppServiceDev, videoAppServiceStage, videoAppServiceProd)
+            whenever(sharedPreferences.getString(Preferences.ENVIRONMENT, Preferences.ENVIRONMENT_DEFAULT))
+                    .thenReturn(TWILIO_API_STAGE_ENV)
 
-        val testObserver = videoAppServiceDelegate.getToken(identity, roomProperties).test()
-
-        testObserver.assertValue(stageTestToken)
+            val token = videoAppServiceDelegate.getToken(identity, roomProperties)
+            assertThat(token, equalTo(stageTestToken))
+        }
     }
 
     @Test
     fun `getToken should retrieve dev environment token successfully`() {
-        val videoAppServiceDelegate = VideoAppServiceDelegate(sharedPreferences, videoAppServiceDev, videoAppServiceStage, videoAppServiceProd)
-        whenever(sharedPreferences.getString(Preferences.ENVIRONMENT, Preferences.ENVIRONMENT_DEFAULT))
-                .thenReturn(TWILIO_API_DEV_ENV)
+        coroutineScope.runBlockingTest {
+            setupMocks()
+            val videoAppServiceDelegate = VideoAppServiceDelegate(sharedPreferences, videoAppServiceDev, videoAppServiceStage, videoAppServiceProd)
+            whenever(sharedPreferences.getString(Preferences.ENVIRONMENT, Preferences.ENVIRONMENT_DEFAULT))
+                    .thenReturn(TWILIO_API_DEV_ENV)
 
-        val testObserver = videoAppServiceDelegate.getToken(identity, roomProperties).test()
-
-        testObserver.assertValue(devTestToken)
+            val token = videoAppServiceDelegate.getToken(identity, roomProperties)
+            assertThat(token, equalTo(devTestToken))
+        }
     }
 
-    private fun mockService(mock: VideoAppService, token: String) {
-        whenever(mock.getToken(
-                identity,
-                roomProperties.name,
-                "production",
-                roomProperties.topology.string,
-                roomProperties.isRecordParticipantsOnConnect
-        )
-        ).thenReturn(Single.just(token))
+    private suspend fun setupMocks() {
+        videoAppServiceDev = mock {
+            mockService(mock, devTestToken)
+        }
+        videoAppServiceStage = mock {
+            mockService(mock, stageTestToken)
+        }
+        videoAppServiceProd = mock {
+            mockService(mock, prodTestToken)
+        }
+    }
+
+    private suspend fun mockService(mock: VideoAppService, token: String) {
+            whenever(mock.getToken(
+                    identity,
+                    roomProperties.name,
+                    "production",
+                    roomProperties.topology.string,
+                    roomProperties.isRecordParticipantsOnConnect))
+                    .thenReturn(token)
     }
 }

--- a/app/src/test/java/com/twilio/video/app/util/MainCoroutineScopeRule.kt
+++ b/app/src/test/java/com/twilio/video/app/util/MainCoroutineScopeRule.kt
@@ -1,6 +1,22 @@
 package com.twilio.video.app.util
 
 /*
+ * Copyright (C) 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
  * Source is from https://github.com/googlecodelabs/kotlin-coroutines/blob/master/coroutines-codelab/finished_code/src/test/java/com/example/android/kotlincoroutines/main/utils/MainCoroutineScopeRule.kt
  * Since this isn't available as part of a library yet.
  */

--- a/app/src/test/java/com/twilio/video/app/util/MainCoroutineScopeRule.kt
+++ b/app/src/test/java/com/twilio/video/app/util/MainCoroutineScopeRule.kt
@@ -1,0 +1,73 @@
+package com.twilio.video.app.util
+
+/*
+ * Source is from https://github.com/googlecodelabs/kotlin-coroutines/blob/master/coroutines-codelab/finished_code/src/test/java/com/example/android/kotlincoroutines/main/utils/MainCoroutineScopeRule.kt
+ * Since this isn't available as part of a library yet.
+ */
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * MainCoroutineRule installs a TestCoroutineDispatcher for Disptachers.Main.
+ *
+ * Since it extends TestCoroutineScope, you can directly launch coroutines on the MainCoroutineRule
+ * as a [CoroutineScope]:
+ *
+ * ```
+ * mainCoroutineRule.launch { aTestCoroutine() }
+ * ```
+ *
+ * All coroutines started on [MainCoroutineScopeRule] must complete (including timeouts) before the test
+ * finishes, or it will throw an exception.
+ *
+ * When using MainCoroutineRule you should always invoke runBlockingTest on it to avoid creating two
+ * instances of [TestCoroutineDispatcher] or [TestCoroutineScope] in your test:
+ *
+ * ```
+ * @Test
+ * fun usingRunBlockingTest() = mainCoroutineRule.runBlockingTest {
+ *     aTestCoroutine()
+ * }
+ * ```
+ *
+ * You may call [DelayController] methods on [MainCoroutineScopeRule] and they will control the
+ * virtual-clock.
+ *
+ * ```
+ * mainCoroutineRule.pauseDispatcher()
+ * // do some coroutines
+ * mainCoroutineRule.advanceUntilIdle() // run all pending coroutines until the dispatcher is idle
+ * ```
+ *
+ * By default, [MainCoroutineScopeRule] will be in a *resumed* state.
+ *
+ * @param dispatcher if provided, this [TestCoroutineDispatcher] will be used.
+ */
+@ExperimentalCoroutinesApi
+class MainCoroutineScopeRule(val dispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()) :
+        TestWatcher(),
+        TestCoroutineScope by TestCoroutineScope(dispatcher) {
+    override fun starting(description: Description?) {
+        super.starting(description)
+        // If your codebase allows the injection of other dispatchers like
+        // Dispatchers.Default and Dispatchers.IO, consider injecting all of them here
+        // and renaming this class to `CoroutineScopeRule`
+        //
+        // All injected dispatchers in a test should point to a single instance of
+        // TestCoroutineDispatcher.
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description?) {
+        super.finished(description)
+        cleanupTestCoroutines()
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
## Description

Replaced RxJava logic that retrieves a token from the TokenService with Kotlin Coroutines. I also introduced a ViewModel in between the RoomActivity and RoomManager as a first step to getting closer to an MVVM architecture. Executing coroutines from a ViewModel is also recommended as it manages its own coroutine scope that is tied to the view model's lifecycle.

The changes to the RoomActivity look large, but that's because I moved the methods related to fetching the token and connecting to a room over to the RoomManager. Mainly pay attention to where the connectToRoom function gets invoked in the connectButtonClick method and where the view model gets initialized in onCreate.

## Breakdown

- Modified DI to allow injection of TokenService in the RoomManager.
- Swapped out RxJava with Coroutines within the TokenService logic.
- Added RoomViewModel.
- Moved token retrieval and room connection logic to RoomManager.

## Validation

- Passed manual validation
- Passed CI pipeline.

## Additional Notes

N/A

## Submission Checklist

 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
