### PR TITLE
Upgrade gradle and kotlin plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,11 +78,11 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         classpath "com.jakewharton:butterknife-gradle-plugin:${versions.butterknife}"
         classpath "com.google.gms:google-services:4.3.3"
         classpath "io.fabric.tools:gradle:1.31.0"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.70"
     }
 }
 


### PR DESCRIPTION
## Description

Upgrade kotlin and gradle plugins.

## Breakdown

- Upgrade gradle plugin to 3.6.1.
- Upgrade kotlin gradle plugin to 1.3.70

## Validation

- Manual validation.
- Passed CI.

## Additional Notes

N/A

## Submission Checklist

 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
