### PR TITLE
Token error regression fix

### DIFF
--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/RoomTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/RoomTest.kt
@@ -1,0 +1,52 @@
+package com.twilio.video.app.e2eTest
+
+import androidx.test.ext.junit.rules.activityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.twilio.video.app.screen.assertRoomIsConnected
+import com.twilio.video.app.screen.assertScreenIsDisplayed
+import com.twilio.video.app.screen.clickDisconnectButton
+import com.twilio.video.app.screen.clickJoinRoomButton
+import com.twilio.video.app.screen.clickMicButton
+import com.twilio.video.app.screen.clickVideoButton
+import com.twilio.video.app.screen.enterRoomName
+import com.twilio.video.app.ui.splash.SplashActivity
+import com.twilio.video.app.util.retryEspressoAction
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class RoomTest : BaseUITest() {
+
+    @get:Rule
+    var scenario = activityScenarioRule<SplashActivity>()
+
+    @Test
+    fun it_should_connect_to_a_room_successfully() {
+        retryEspressoAction { assertScreenIsDisplayed() }
+
+        enterRoomName(UUID.randomUUID().toString())
+        clickJoinRoomButton()
+
+        retryEspressoAction { assertRoomIsConnected() }
+
+        clickDisconnectButton()
+    }
+
+    @Test
+    fun it_should_connect_to_a_room_successfully_with_mic_and_video_muted() {
+        retryEspressoAction { assertScreenIsDisplayed() }
+
+        clickVideoButton()
+        clickMicButton()
+        enterRoomName(UUID.randomUUID().toString())
+        clickJoinRoomButton()
+
+        retryEspressoAction { assertRoomIsConnected() }
+
+        clickDisconnectButton()
+    }
+}

--- a/app/src/androidTest/java/com/twilio/video/app/screen/LobbyScreen.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/screen/LobbyScreen.kt
@@ -5,15 +5,13 @@ import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.matcher.ViewMatchers.hasChildCount
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.twilio.video.app.R
 import com.twilio.video.app.util.getString
 import com.twilio.video.app.util.getTargetContext
-import org.hamcrest.CoreMatchers.allOf
 
 fun assertScreenIsDisplayed() {
     onView(withText(getString(R.string.join))).check(matches(isDisplayed()))
@@ -32,13 +30,20 @@ fun enterRoomName(roomName: String) {
     onView(withId(R.id.room_edit_text)).perform(typeText(roomName))
 }
 
+fun clickVideoButton() {
+    onView(withId(R.id.local_video_image_button)).perform(click())
+}
+
+fun clickMicButton() {
+    onView(withId(R.id.local_audio_image_button)).perform(click())
+}
+
 fun clickJoinRoomButton() {
     onView(withId(R.id.connect)).perform(click())
 }
 
 fun assertRoomIsConnected() {
-    onView(allOf(withId(R.id.participant_stub_image),
-            withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE))).check(matches(isDisplayed()))
+    onView(withId(R.id.remote_video_thumbnails)).check(matches(hasChildCount(1)))
 }
 
 fun clickDisconnectButton() {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -492,10 +492,16 @@ public class RoomActivity extends BaseActivity {
             roomViewModel.connectToRoom(
                     displayName,
                     roomName,
-                    Collections.singletonList(localAudioTrack),
+                    getLocalAudioTracks(),
                     getLocalVideoTracks(),
                     isNetworkQualityEnabled());
         }
+    }
+
+    private List<LocalAudioTrack> getLocalAudioTracks() {
+        return localAudioTrack != null
+                ? Collections.singletonList(localAudioTrack)
+                : Collections.emptyList();
     }
 
     private List<LocalVideoTrack> getLocalVideoTracks() {


### PR DESCRIPTION
## Description

Fixed token error display regression when muting audio track before joining a room.

## Breakdown

- Check null LocalAudioTrack before adding it to the list of LocalAudioTracks
- Added e2e regression tests

## Validation

- Manual validation
- Passed CI

## Additional Notes

N/A

## Submission Checklist

 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
