### PR TITLE
AHOYAPPS-430: No local video publishing when backgrounding

### DIFF
--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -321,9 +321,7 @@ public class RoomActivity extends BaseActivity {
 
         updateStats();
 
-        // TODO Remove once the ViewModel is used to persist the view state
-        RoomEvent currentRoomEvent = roomViewModel.getRoomEvents().getValue();
-        if (isPostRoomConnectionEvent(currentRoomEvent)) addParticipantViews();
+        addParticipantViews();
     }
 
     @Override
@@ -331,15 +329,6 @@ public class RoomActivity extends BaseActivity {
         super.onResume();
         displayName = sharedPreferences.getString(Preferences.DISPLAY_NAME, null);
         setTitle(displayName);
-    }
-
-    private boolean isPostRoomConnectionEvent(RoomEvent currentRoomEvent) {
-        return currentRoomEvent != null
-                && currentRoomEvent.getRoom() != null
-                && (currentRoomEvent.getRoom().getState() == CONNECTED
-                        || currentRoomEvent instanceof RoomEvent.ParticipantConnected
-                        || currentRoomEvent instanceof RoomEvent.ParticipantDisconnected
-                        || currentRoomEvent instanceof RoomEvent.DominantSpeakerChanged);
     }
 
     private boolean checkIntentURI() {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -314,9 +314,9 @@ public class RoomActivity extends BaseActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        boolean isAppLinkProvided = checkIntentURI();
+        checkIntentURI();
         displayName = sharedPreferences.getString(Preferences.DISPLAY_NAME, null);
-        updateUi(room, isAppLinkProvided);
+        updateUi(room);
         restoreCameraTrack();
         initializeRoom();
         updateStats();
@@ -780,17 +780,13 @@ public class RoomActivity extends BaseActivity {
     }
 
     private void updateUi(Room room) {
-        updateUi(room, false);
-    }
-
-    private void updateUi(Room room, boolean isAppLinkProvided) {
         int disconnectButtonState = View.GONE;
         int joinRoomLayoutState = View.VISIBLE;
         int joinStatusLayoutState = View.GONE;
 
         boolean settingsMenuItemState = true;
 
-        boolean connectButtonEnabled = isAppLinkProvided;
+        boolean connectButtonEnabled = !roomEditText.getText().toString().isEmpty();
 
         String roomName = displayName;
         String toolbarTitle = displayName;

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -353,7 +353,6 @@ public class RoomActivity extends BaseActivity {
     @Override
     protected void onDestroy() {
         // Reset the speakerphone
-        VideoService.Companion.stopService(this);
         audioManager.setSpeakerphoneOn(false);
         // Teardown tracks
         if (localAudioTrack != null) {
@@ -1339,7 +1338,6 @@ public class RoomActivity extends BaseActivity {
                     State state = room.getState();
                     switch (state) {
                         case CONNECTED:
-                            VideoService.Companion.startService(this);
                             initializeRoom();
                             break;
                         case DISCONNECTED:

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -97,6 +97,7 @@ import com.twilio.video.app.data.Preferences;
 import com.twilio.video.app.data.api.TokenService;
 import com.twilio.video.app.data.api.VideoAppService;
 import com.twilio.video.app.ui.room.RoomEvent.ConnectFailure;
+import com.twilio.video.app.ui.room.RoomEvent.Connecting;
 import com.twilio.video.app.ui.room.RoomEvent.DominantSpeakerChanged;
 import com.twilio.video.app.ui.room.RoomEvent.ParticipantConnected;
 import com.twilio.video.app.ui.room.RoomEvent.ParticipantDisconnected;
@@ -770,7 +771,7 @@ public class RoomActivity extends BaseActivity {
         primaryVideoView.showIdentityBadge(false);
     }
 
-    private void updateUi(Room room) {
+    private void updateUi(Room room, RoomEvent roomEvent) {
         int disconnectButtonState = View.GONE;
         int joinRoomLayoutState = View.VISIBLE;
         int joinStatusLayoutState = View.GONE;
@@ -785,21 +786,23 @@ public class RoomActivity extends BaseActivity {
         String joinStatus = "";
         int recordingWarningVisibility = View.GONE;
 
+        if (roomEvent instanceof Connecting) {
+            disconnectButtonState = View.VISIBLE;
+            joinRoomLayoutState = View.GONE;
+            joinStatusLayoutState = View.VISIBLE;
+            recordingWarningVisibility = View.VISIBLE;
+            settingsMenuItemState = false;
+
+            connectButtonEnabled = false;
+
+            if (roomEditable != null) {
+                roomName = roomEditable.toString();
+            }
+            joinStatus = "Joining...";
+        }
+
         if (room != null) {
             switch (room.getState()) {
-                case CONNECTING:
-                    disconnectButtonState = View.VISIBLE;
-                    joinRoomLayoutState = View.GONE;
-                    joinStatusLayoutState = View.VISIBLE;
-                    recordingWarningVisibility = View.VISIBLE;
-                    settingsMenuItemState = false;
-
-                    connectButtonEnabled = false;
-
-                    roomName = room.getName();
-                    joinStatus = "Joining...";
-
-                    break;
                 case CONNECTED:
                     disconnectButtonState = View.VISIBLE;
                     joinRoomLayoutState = View.GONE;
@@ -1410,7 +1413,6 @@ public class RoomActivity extends BaseActivity {
                         }
                     }
                 }
-                updateUi(room);
             } else {
                 if (roomEvent instanceof TokenError) {
                     new AlertDialog.Builder(this, R.style.AppTheme_Dialog)
@@ -1421,6 +1423,7 @@ public class RoomActivity extends BaseActivity {
                             .show();
                 }
             }
+            updateUi(room, roomEvent);
         }
     }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -108,8 +108,6 @@ import com.twilio.video.app.util.CameraCapturerCompat;
 import com.twilio.video.app.util.InputUtils;
 import com.twilio.video.app.util.StatsScheduler;
 import io.reactivex.disposables.CompositeDisposable;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -522,26 +520,8 @@ public class RoomActivity extends BaseActivity {
         if (text != null) {
             final String roomName = text.toString();
 
-            roomViewModel.connectToRoom(
-                    displayName,
-                    roomName,
-                    getLocalAudioTracks(),
-                    getLocalVideoTracks(),
-                    isNetworkQualityEnabled());
+            roomViewModel.connectToRoom(displayName, roomName, isNetworkQualityEnabled());
         }
-    }
-
-    private List<LocalAudioTrack> getLocalAudioTracks() {
-        return localAudioTrack != null
-                ? Collections.singletonList(localAudioTrack)
-                : Collections.emptyList();
-    }
-
-    private List<LocalVideoTrack> getLocalVideoTracks() {
-        List<LocalVideoTrack> localVideoTracks = new ArrayList<>();
-        if (cameraVideoTrack != null) localVideoTracks.add(cameraVideoTrack);
-        if (screenVideoTrack != null) localVideoTracks.add(screenVideoTrack);
-        return localVideoTracks;
     }
 
     @OnClick(R.id.disconnect)

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -1281,6 +1281,10 @@ public class RoomActivity extends BaseActivity {
             if (localAudioTrack != null) {
                 localParticipant.publishTrack(localAudioTrack);
             }
+
+            if (screenVideoTrack != null) {
+                localParticipant.publishTrack(screenVideoTrack);
+            }
         }
     }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -777,7 +777,8 @@ public class RoomActivity extends BaseActivity {
 
         boolean settingsMenuItemState = true;
 
-        boolean connectButtonEnabled = !roomEditText.getText().toString().isEmpty();
+        Editable roomEditable = roomEditText.getText();
+        boolean connectButtonEnabled = roomEditable != null && !roomEditable.toString().isEmpty();
 
         String roomName = displayName;
         String toolbarTitle = displayName;

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -1281,10 +1281,6 @@ public class RoomActivity extends BaseActivity {
             if (localAudioTrack != null) {
                 localParticipant.publishTrack(localAudioTrack);
             }
-
-            if (screenVideoTrack != null) {
-                localParticipant.publishTrack(screenVideoTrack);
-            }
         }
     }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -414,9 +414,6 @@ public class RoomActivity extends BaseActivity {
         pauseAudioMenuItem = menu.findItem(R.id.pause_audio_menu_item);
         screenCaptureMenuItem = menu.findItem(R.id.share_screen_menu_item);
 
-        // Screen sharing only available on lollipop and up
-        screenCaptureMenuItem.setVisible(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP);
-
         requestPermissions();
         roomViewModel.getRoomEvents().observe(this, this::bindRoomEvents);
 
@@ -776,6 +773,7 @@ public class RoomActivity extends BaseActivity {
         int joinStatusLayoutState = View.GONE;
 
         boolean settingsMenuItemState = true;
+        boolean screenCaptureMenuItemState = false;
 
         Editable roomEditable = roomEditText.getText();
         boolean connectButtonEnabled = roomEditable != null && !roomEditable.toString().isEmpty();
@@ -807,6 +805,7 @@ public class RoomActivity extends BaseActivity {
                     joinRoomLayoutState = View.GONE;
                     joinStatusLayoutState = View.GONE;
                     settingsMenuItemState = false;
+                    screenCaptureMenuItemState = true;
 
                     connectButtonEnabled = false;
 
@@ -817,6 +816,7 @@ public class RoomActivity extends BaseActivity {
                     break;
                 case DISCONNECTED:
                     connectButtonEnabled = true;
+                    screenCaptureMenuItemState = false;
                     break;
             }
         }
@@ -847,6 +847,11 @@ public class RoomActivity extends BaseActivity {
         // TODO: Remove when we use a Service to obtainTokenAndConnect to a room
         if (settingsMenuItem != null) {
             settingsMenuItem.setVisible(settingsMenuItemState);
+        }
+
+        if (screenCaptureMenuItem != null
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            screenCaptureMenuItem.setVisible(screenCaptureMenuItemState);
         }
     }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomEvent.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomEvent.kt
@@ -5,7 +5,7 @@ import com.twilio.video.Room
 
 sealed class RoomEvent(val room: Room? = null) {
     object TokenError : RoomEvent()
-    class Connecting(room: Room) : RoomEvent(room)
+    object Connecting : RoomEvent()
     class RoomState(room: Room) : RoomEvent(room)
     class ConnectFailure(room: Room) : RoomEvent(room)
     class ParticipantConnected(room: Room, val remoteParticipant: RemoteParticipant) : RoomEvent(room)

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -11,8 +11,6 @@ import com.twilio.video.EncodingParameters
 import com.twilio.video.G722Codec
 import com.twilio.video.H264Codec
 import com.twilio.video.IsacCodec
-import com.twilio.video.LocalAudioTrack
-import com.twilio.video.LocalVideoTrack
 import com.twilio.video.NetworkQualityConfiguration
 import com.twilio.video.NetworkQualityVerbosity
 import com.twilio.video.OpusCodec
@@ -61,8 +59,6 @@ class RoomManager(
     suspend fun connectToRoom(
         identity: String,
         roomName: String,
-        localAudioTracks: List<LocalAudioTrack>,
-        localVideoTracks: List<LocalVideoTrack>,
         isNetworkQualityEnabled: Boolean
     ) {
         coroutineScope.launch {
@@ -106,14 +102,6 @@ class RoomManager(
                         Preferences.MAX_AUDIO_BITRATE_DEFAULT)
 
                 val encodingParameters = EncodingParameters(maxAudioBitrate, maxVideoBitrate)
-
-                if (localAudioTracks.isNotEmpty()) {
-                    connectOptionsBuilder.audioTracks(localAudioTracks.filter { it.isEnabled })
-                }
-
-                if (localVideoTracks.isNotEmpty()) {
-                    connectOptionsBuilder.videoTracks(localVideoTracks.filter { it.isEnabled })
-                }
 
                 connectOptionsBuilder.preferVideoCodecs(listOf(preferedVideoCodec))
                 connectOptionsBuilder.preferAudioCodecs(listOf(preferredAudioCodec))

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -63,6 +63,7 @@ class RoomManager(
     ) {
         coroutineScope.launch {
             try {
+                mutableViewEvents.postValue(Connecting)
                 setSdkEnvironment(sharedPreferences)
                 val token = tokenService.getToken(identity, roomName)
                 val enableInsights = sharedPreferences.getBoolean(
@@ -112,8 +113,6 @@ class RoomManager(
                         connectOptionsBuilder.build(),
                         roomListener)
                 this@RoomManager.room = room
-
-                mutableViewEvents.postValue(Connecting(room))
             } catch (e: Exception) {
                 Timber.e(e, "Failed to retrieve token")
                 mutableViewEvents.postValue(TokenError)

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -108,11 +108,11 @@ class RoomManager(
                 val encodingParameters = EncodingParameters(maxAudioBitrate, maxVideoBitrate)
 
                 if (localAudioTracks.isNotEmpty()) {
-                    connectOptionsBuilder.audioTracks(localAudioTracks)
+                    connectOptionsBuilder.audioTracks(localAudioTracks.filter { it.isEnabled })
                 }
 
                 if (localVideoTracks.isNotEmpty()) {
-                    connectOptionsBuilder.videoTracks(localVideoTracks)
+                    connectOptionsBuilder.videoTracks(localVideoTracks.filter { it.isEnabled })
                 }
 
                 connectOptionsBuilder.preferVideoCodecs(listOf(preferedVideoCodec))

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -180,7 +180,7 @@ class RoomManager(
         override fun onDisconnected(room: Room, twilioException: TwilioException?) {
             Timber.i("Disconnected from room -> sid: %s, state: %s",
                     room.sid, room.state)
-            
+
             stopService(context)
 
             mutableViewEvents.value = RoomState(room)

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -32,6 +32,8 @@ import com.twilio.video.app.ui.room.RoomEvent.ParticipantConnected
 import com.twilio.video.app.ui.room.RoomEvent.ParticipantDisconnected
 import com.twilio.video.app.ui.room.RoomEvent.RoomState
 import com.twilio.video.app.ui.room.RoomEvent.TokenError
+import com.twilio.video.app.ui.room.VideoService.Companion.startService
+import com.twilio.video.app.ui.room.VideoService.Companion.stopService
 import com.twilio.video.app.util.EnvUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -168,12 +170,19 @@ class RoomManager(
         override fun onConnected(room: Room) {
             Timber.i("onConnected -> room sid: %s",
                     room.sid)
+
+            startService(context)
+
+            // Reset the speakerphone
             mutableViewEvents.value = RoomState(room)
         }
 
         override fun onDisconnected(room: Room, twilioException: TwilioException?) {
             Timber.i("Disconnected from room -> sid: %s, state: %s",
                     room.sid, room.state)
+            
+            stopService(context)
+
             mutableViewEvents.value = RoomState(room)
         }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomManager.kt
@@ -180,7 +180,7 @@ class RoomManager(
         override fun onDisconnected(room: Room, twilioException: TwilioException?) {
             Timber.i("Disconnected from room -> sid: %s, state: %s",
                     room.sid, room.state)
-
+            
             stopService(context)
 
             mutableViewEvents.value = RoomState(room)

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.twilio.video.LocalAudioTrack
-import com.twilio.video.LocalVideoTrack
 import kotlinx.coroutines.launch
 
 class RoomViewModel(private val roomManager: RoomManager) : ViewModel() {
@@ -18,16 +16,12 @@ class RoomViewModel(private val roomManager: RoomManager) : ViewModel() {
     fun connectToRoom(
         identity: String,
         roomName: String,
-        localAudioTracks: List<LocalAudioTrack>,
-        localVideoTracks: List<LocalVideoTrack>,
         isNetworkQualityEnabled: Boolean
     ) =
         viewModelScope.launch {
             roomManager.connectToRoom(
                     identity,
                     roomName,
-                    localAudioTracks,
-                    localVideoTracks,
                     isNetworkQualityEnabled)
         }
 

--- a/app/src/main/res/menu/room_menu.xml
+++ b/app/src/main/res/menu/room_menu.xml
@@ -16,6 +16,7 @@
     <item android:id="@+id/share_screen_menu_item"
           android:title="@string/share_screen"
           android:icon="@drawable/ic_screen_share_white_24dp"
+          android:visible="false"
           app:showAsAction="ifRoom"/>
 
     <item android:id="@+id/pause_audio_menu_item"


### PR DESCRIPTION
## Description

Fixed local video and audio track publishing issues when backgrounding the app while attempting to connect to a room. This PR also includes a fix for [AHOYAPPS-352](https://issues.corp.twilio.com/browse/AHOYAPPS-352).

## Breakdown

- Removed audio and video tracks from the ConnectOptionsBuilder, and delay publishing of tracks until connecting to a room.
- Ensured onStart is invoked before the observable method bindRoomEvents to ensure the camera track is setup properly before publishing to the room.
- Cleaned up initializeRoom method.

## Validation

- Manually validated by following bug reproduction steps on 2 Android devices.
- Passed CI pipeline.

## Additional Notes

N/A

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
