### PR TITLE
AHOYAPPS-534 Fix crash on devices below 21

### DIFF
--- a/app/src/main/res/drawable/roundbutton.xml
+++ b/app/src/main/res/drawable/roundbutton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
-    <solid android:color="?attr/colorAccent"/>
+    <solid android:color="@color/colorAccent"/>
     <padding android:left="10dp"
              android:right="10dp"
              android:bottom="10dp"

--- a/app/src/main/res/drawable/splash_screen.xml
+++ b/app/src/main/res/drawable/splash_screen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android"
     android:opacity="opaque">
-    <item android:drawable="?attr/colorPrimary" />
+    <item android:drawable="@color/colorPrimary" />
     <item>
         <bitmap
             android:gravity="center"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,7 +8,7 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
-    <style name="AppTheme.NoActionBar" parent="Theme.AppCompat.NoActionBar">
+    <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="windowActionModeOverlay">true</item>

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:3.6.2'
         classpath "com.jakewharton:butterknife-gradle-plugin:${versions.butterknife}"
         classpath "com.google.gms:google-services:4.3.3"
         classpath "io.fabric.tools:gradle:1.31.0"


### PR DESCRIPTION
## Description

Fix crash when launching the app on devices below API 21.

## Breakdown

- Update gradle plugin
- Change color references in themes
- Remove parent theme of login screen

## Validation

- Launched app on Android 18 device and successfully connected to room.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
