### PR TITLE
AHOYAPPS-579: Fix conceal release build type crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ If any errors occur after running a [Twilio CLI RTC Plugin](https://github.com/t
 Currently there are three product flavors for the application.
 
 1. Internal - The application intended for internal testing and QA at Twilio. _This variant can only be built by Twilions._
-1. Twilio - The application intended for every day use at Twilio. _This variant can only be built by Twilions._
-1. Community - The application intended for developers interested in using Programmable Video. _This variant can be built by all developers._
+2. Twilio - The application intended for every day use at Twilio. _This variant can only be built by Twilions._
+3. Community - The application intended for developers interested in using Programmable Video. _This variant can be built by all developers._
+   1. debug and release build types are supported.
 
 #### Building the Community Flavor
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,8 +125,7 @@ android {
         def names = variant.flavors*.name
 
         // Ignore twilio debug and community release builds
-        if ((names.contains("twilio") && variant.buildType.name == "debug") ||
-                (names.contains("community") && variant.buildType.name == "release")) {
+        if ((names.contains("twilio") && variant.buildType.name == "debug")) {
             setIgnore(true)
         }
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -3,3 +3,8 @@
 -keep class com.twilio.video.** { *; }
 -keep class com.twilio.common.** { *; }
 -keepattributes InnerClasses
+
+# Facebook Conceal proguard config
+-keep class com.facebook.crypto.** { *; }
+-keep class com.facebook.jni.** { *; }
+-keepclassmembers class com.facebook.cipher.jni.** { *; }


### PR DESCRIPTION
## Description

Fix a crash caused by the release build type obfuscating the Facebook conceal dependency.

## Breakdown

- Add facebook conceal Proguard configuration to `proguard-pro.rules`

## Validation

- Manually test communityRelease by logging in
- Pass CI pipeline

## Additional Notes

N/A

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
