### PR TITLE
Manage Video Track Priorities

### DIFF
--- a/app/src/main/java/com/twilio/video/app/participant/ParticipantManager.kt
+++ b/app/src/main/java/com/twilio/video/app/participant/ParticipantManager.kt
@@ -1,8 +1,7 @@
 package com.twilio.video.app.participant
 
 import com.twilio.video.NetworkQualityLevel
-import com.twilio.video.RemoteVideoTrack
-import com.twilio.video.TrackPriority
+import com.twilio.video.TrackPriority.HIGH
 import com.twilio.video.app.sdk.VideoTrackViewState
 import timber.log.Timber
 
@@ -119,26 +118,24 @@ class ParticipantManager {
 
     private fun setTrackPriority(participant: ParticipantViewState) {
         when {
-            participant.isPinned -> {
-                setVideoTrackPriority(participant)
-            }
             participant.isScreenSharing -> {
-                (participant.screenTrack?.videoTrack as RemoteVideoTrack?)?.priority =
-                        TrackPriority.HIGH
+                participant.getRemoteScreenTrack()?.priority = HIGH
             }
             participant.isDominantSpeaker -> {
-                setVideoTrackPriority(participant, null)
+                participant.getRemoteVideoTrack()?.priority = null
             }
             else -> {
-                setVideoTrackPriority(participant)
+                participant.getRemoteVideoTrack()?.priority = HIGH
             }
         }
+
+        clearOldTrackPriorities()
     }
 
-    private fun setVideoTrackPriority(
-        participant: ParticipantViewState,
-        priority: TrackPriority? = TrackPriority.HIGH
-    ) {
-        (participant.videoTrack?.videoTrack as RemoteVideoTrack?)?.priority = priority
+    private fun clearOldTrackPriorities() {
+        primaryParticipant?.run {
+            getRemoteVideoTrack()?.priority = null
+            getRemoteScreenTrack()?.priority = null
+        }
     }
 }

--- a/app/src/main/java/com/twilio/video/app/participant/ParticipantViewState.kt
+++ b/app/src/main/java/com/twilio/video/app/participant/ParticipantViewState.kt
@@ -17,7 +17,9 @@ data class ParticipantViewState(
     val isDominantSpeaker: Boolean = false,
     val isLocalParticipant: Boolean = false,
     val networkQualityLevel: NetworkQualityLevel = NETWORK_QUALITY_LEVEL_UNKNOWN
-)
+) {
+    val isScreenSharing: Boolean get() = screenTrack != null
+}
 
 fun buildParticipantViewState(participant: Participant): ParticipantViewState {
     val videoTrack = participant.videoTracks.firstOrNull()?.videoTrack

--- a/app/src/main/java/com/twilio/video/app/participant/ParticipantViewState.kt
+++ b/app/src/main/java/com/twilio/video/app/participant/ParticipantViewState.kt
@@ -4,6 +4,7 @@ import com.twilio.video.LocalVideoTrack
 import com.twilio.video.NetworkQualityLevel
 import com.twilio.video.NetworkQualityLevel.NETWORK_QUALITY_LEVEL_UNKNOWN
 import com.twilio.video.Participant
+import com.twilio.video.RemoteVideoTrack
 import com.twilio.video.app.sdk.VideoTrackViewState
 
 data class ParticipantViewState(
@@ -19,6 +20,12 @@ data class ParticipantViewState(
     val networkQualityLevel: NetworkQualityLevel = NETWORK_QUALITY_LEVEL_UNKNOWN
 ) {
     val isScreenSharing: Boolean get() = screenTrack != null
+
+    fun getRemoteVideoTrack(): RemoteVideoTrack? =
+            if (!isLocalParticipant) videoTrack?.videoTrack as RemoteVideoTrack? else null
+
+    fun getRemoteScreenTrack(): RemoteVideoTrack? =
+            if (!isLocalParticipant) screenTrack?.videoTrack as RemoteVideoTrack? else null
 }
 
 fun buildParticipantViewState(participant: Participant): ParticipantViewState {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -70,10 +70,12 @@ import com.twilio.video.AspectRatio;
 import com.twilio.video.CameraCapturer;
 import com.twilio.video.LocalAudioTrack;
 import com.twilio.video.LocalParticipant;
+import com.twilio.video.LocalTrackPublicationOptions;
 import com.twilio.video.LocalVideoTrack;
 import com.twilio.video.Room;
 import com.twilio.video.ScreenCapturer;
 import com.twilio.video.StatsListener;
+import com.twilio.video.TrackPriority;
 import com.twilio.video.VideoConstraints;
 import com.twilio.video.VideoDimensions;
 import com.twilio.video.app.R;
@@ -559,7 +561,7 @@ public class RoomActivity extends BaseActivity {
                             videoConstraints,
                             CAMERA_TRACK_NAME);
             if (localParticipant != null && cameraVideoTrack != null) {
-                localParticipant.publishTrack(cameraVideoTrack);
+                publishVideoTrack(cameraVideoTrack, TrackPriority.LOW);
 
                 // enable video settings
                 switchCameraMenuItem.setVisible(cameraVideoTrack.isEnabled());
@@ -590,6 +592,12 @@ public class RoomActivity extends BaseActivity {
                 cameraVideoTrack != null
                         ? R.drawable.ic_videocam_white_24px
                         : R.drawable.ic_videocam_off_gray_24px);
+    }
+
+    private void publishVideoTrack(LocalVideoTrack videoTrack, TrackPriority trackPriority) {
+        LocalTrackPublicationOptions localTrackPublicationOptions =
+                new LocalTrackPublicationOptions(trackPriority);
+        localParticipant.publishTrack(videoTrack, localTrackPublicationOptions);
     }
 
     private boolean isNetworkQualityEnabled() {
@@ -686,7 +694,7 @@ public class RoomActivity extends BaseActivity {
         if (cameraVideoTrack == null && !isVideoMuted) {
             setupLocalVideoTrack();
             if (room != null && localParticipant != null)
-                localParticipant.publishTrack(cameraVideoTrack);
+                publishVideoTrack(cameraVideoTrack, TrackPriority.LOW);
         }
     }
 
@@ -862,7 +870,7 @@ public class RoomActivity extends BaseActivity {
                     screenVideoTrack.getName(), getString(R.string.screen_video_track));
 
             if (localParticipant != null) {
-                localParticipant.publishTrack(screenVideoTrack);
+                publishVideoTrack(screenVideoTrack, TrackPriority.HIGH);
             }
         } else {
             Snackbar.make(
@@ -1004,7 +1012,7 @@ public class RoomActivity extends BaseActivity {
         if (localParticipant != null) {
             if (cameraVideoTrack != null) {
                 Timber.d("Camera track: %s", cameraVideoTrack);
-                localParticipant.publishTrack(cameraVideoTrack);
+                publishVideoTrack(cameraVideoTrack, TrackPriority.LOW);
             }
 
             if (localAudioTrack != null) {

--- a/app/src/test/java/com/twilio/video/app/participant/ParticipantManagerTest.kt
+++ b/app/src/test/java/com/twilio/video/app/participant/ParticipantManagerTest.kt
@@ -160,7 +160,7 @@ class ParticipantManagerTest {
     }
 
     @Test
-    fun `primary participant VideoTrack priority should be null when dominant speaker`() {
+    fun `primary participant VideoTrack priority should be null when dominant speaker is set`() {
         val dominantSpeaker = setupThreeParticipantScenario()
 
         participantManager.changeDominantSpeaker(dominantSpeaker.sid)
@@ -170,7 +170,7 @@ class ParticipantManagerTest {
     }
 
     @Test
-    fun `primary participant VideoTrack priority should be not be set when dominant speaker has a null video track`() {
+    fun `primary participant VideoTrack priority should not be set when dominant speaker has a null video track`() {
         val dominantSpeaker = setupThreeParticipantScenario()
 
         participantManager.changeDominantSpeaker(dominantSpeaker.sid)

--- a/app/src/test/java/com/twilio/video/app/ui/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/twilio/video/app/ui/room/RoomViewModelTest.kt
@@ -2,7 +2,7 @@ package com.twilio.video.app.ui.room
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.nhaarman.mockitokotlin2.mock
-import com.twilio.video.VideoTrack
+import com.twilio.video.RemoteVideoTrack
 import com.twilio.video.app.participant.ParticipantManager
 import com.twilio.video.app.participant.ParticipantViewState
 import com.twilio.video.app.sdk.RoomManager
@@ -37,7 +37,7 @@ class RoomViewModelTest {
 
     @Test
     fun `The TrackSwitchOff event should create a new VideoTrackViewState for an existing ParticipantViewState`() {
-        val expectedVideoTrack = mock<VideoTrack>()
+        val expectedVideoTrack = mock<RemoteVideoTrack>()
 
         roomManager.sendParticipantEvent(TrackSwitchOff(PARTICIPANT_SID, expectedVideoTrack, false))
         scheduler.triggerActions()
@@ -53,7 +53,7 @@ class RoomViewModelTest {
 
     @Test
     fun `The TrackSwitchOff event should create a new VideoTrackViewState for an existing ParticipantViewState with the switch off set to true`() {
-        val expectedVideoTrack = mock<VideoTrack>()
+        val expectedVideoTrack = mock<RemoteVideoTrack>()
 
         roomManager.sendParticipantEvent(TrackSwitchOff(PARTICIPANT_SID, expectedVideoTrack, true))
         scheduler.triggerActions()


### PR DESCRIPTION
## Description

https://issues.corp.twilio.com/browse/AHOYAPPS-583
https://issues.corp.twilio.com/browse/AHOYAPPS-675

`LocalVideoTrack` and `RemoteVideoTrack` priorities are now properly managed. The `VideoTrack` that is rendered in the primary participant view for remote participants is now set to a high track priority. The only exception is if the primary participant view is a result of a dominant speaker change, in which case the track priority is set to null.

## Breakdown

- Added track priority to `LocalVideoTrack` publishing in the `RoomActivity`
- `RemoteVideoTrack` priorities are now managed in the `ParticipantManager`
- Added helper functions to retrieve properties in `ParticipantViewState`

## Validation

- Passed CI pipeline
- Passed manual validation on a Pixel XL

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
