### PR TITLE
AHOYAPPS-703: Fix pinning with track priority bug 

### DIFF
--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -11,6 +11,7 @@
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
 # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx20496m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/app/src/main/java/com/twilio/video/app/participant/ParticipantManager.kt
+++ b/app/src/main/java/com/twilio/video/app/participant/ParticipantManager.kt
@@ -117,22 +117,24 @@ class ParticipantManager {
     }
 
     private fun setTrackPriority(participant: ParticipantViewState) {
-        when {
-            participant.isScreenSharing -> {
-                participant.getRemoteScreenTrack()?.priority = HIGH
-                Timber.d("Setting screen track priority to high for participant with sid: ${participant.sid}")
+        if (participant.sid != primaryParticipant?.sid) {
+            when {
+                participant.isScreenSharing -> {
+                    participant.getRemoteScreenTrack()?.priority = HIGH
+                    Timber.d("Setting screen track priority to high for participant with sid: ${participant.sid}")
+                }
+                participant.isDominantSpeaker -> {
+                    participant.getRemoteVideoTrack()?.priority = null
+                    Timber.d("Clearing dominant speaker priority for participant with sid: ${participant.sid}")
+                }
+                else -> {
+                    participant.getRemoteVideoTrack()?.priority = HIGH
+                    Timber.d("Setting video track priority to high for participant with sid: ${participant.sid}")
+                }
             }
-            participant.isDominantSpeaker -> {
-                participant.getRemoteVideoTrack()?.priority = null
-                Timber.d("Clearing dominant speaker priority for participant with sid: ${participant.sid}")
-            }
-            else -> {
-                participant.getRemoteVideoTrack()?.priority = HIGH
-                Timber.d("Setting video track priority to high for participant with sid: ${participant.sid}")
-            }
-        }
 
-        clearOldTrackPriorities()
+            clearOldTrackPriorities()
+        }
     }
 
     private fun clearOldTrackPriorities() {

--- a/app/src/test/java/com/twilio/video/app/participant/ParticipantManagerTest.kt
+++ b/app/src/test/java/com/twilio/video/app/participant/ParticipantManagerTest.kt
@@ -2,11 +2,12 @@ package com.twilio.video.app.participant
 
 import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.twilio.video.LocalVideoTrack
 import com.twilio.video.RemoteVideoTrack
-import com.twilio.video.TrackPriority
+import com.twilio.video.TrackPriority.HIGH
 import com.twilio.video.VideoTrack
 import com.twilio.video.app.sdk.VideoTrackViewState
 import junitparams.JUnitParamsRunner
@@ -107,7 +108,7 @@ class ParticipantManagerTest {
         participantManager.changePinnedParticipant(pinnedParticipant.sid)
 
         val videoTrack = participantManager.primaryParticipant!!.videoTrack!!.videoTrack as RemoteVideoTrack
-        verify(videoTrack).priority = TrackPriority.HIGH
+        verify(videoTrack).priority = HIGH
     }
 
     @Test
@@ -129,7 +130,7 @@ class ParticipantManagerTest {
         participantManager.updateParticipantScreenTrack(screenSharingParticipant.sid,
                 VideoTrackViewState(videoTrack = screenTrack))
 
-        verify(screenTrack).priority = TrackPriority.HIGH
+        verify(screenTrack).priority = HIGH
     }
 
     @Test
@@ -188,7 +189,7 @@ class ParticipantManagerTest {
         participantManager.addParticipant(participant2)
 
         val videoTrack = participantManager.primaryParticipant!!.videoTrack!!.videoTrack as RemoteVideoTrack
-        verify(videoTrack).priority = TrackPriority.HIGH
+        verify(videoTrack).priority = HIGH
     }
 
     @Test
@@ -205,6 +206,18 @@ class ParticipantManagerTest {
     }
 
     @Test
+    fun `primary participant VideoTrack priority should not be set for the same previous participant`() {
+        val participant3 = setupThreeParticipantScenario()
+        val participant2 = participantManager.getParticipant("2")
+
+        participantManager.updateParticipant(participant3.copy(isMuted = true))
+
+        val videoTrack = participant2!!.getRemoteVideoTrack()
+        verify(videoTrack)!!.priority = HIGH
+        verify(videoTrack, times(0))!!.priority = null
+    }
+
+    @Test
     fun `the old primary participant VideoTrack priority should be reset to null when a new participant is assigned`() {
         val participant3 = setupThreeParticipantScenario()
 
@@ -213,7 +226,7 @@ class ParticipantManagerTest {
 
         val videoTrack = participant3.videoTrack!!.videoTrack as RemoteVideoTrack
         inOrder(videoTrack).run {
-            verify(videoTrack).priority = TrackPriority.HIGH
+            verify(videoTrack).priority = HIGH
             verify(videoTrack).priority = null
         }
     }
@@ -228,7 +241,7 @@ class ParticipantManagerTest {
         participantManager.changePinnedParticipant("2")
 
         inOrder(screenTrack).run {
-            verify(screenTrack).priority = TrackPriority.HIGH
+            verify(screenTrack).priority = HIGH
             verify(screenTrack).priority = null
         }
     }
@@ -242,7 +255,7 @@ class ParticipantManagerTest {
 
         val videoTrack = participant3.videoTrack!!.videoTrack as RemoteVideoTrack
         inOrder(videoTrack).run {
-            verify(videoTrack).priority = TrackPriority.HIGH
+            verify(videoTrack).priority = HIGH
             verify(videoTrack).priority = null
         }
     }
@@ -252,12 +265,12 @@ class ParticipantManagerTest {
         setupThreeParticipantScenario()
         val screenTrack = mock<RemoteVideoTrack>()
 
-        participantManager.updateParticipantScreenTrack("2",
+        participantManager.updateParticipantScreenTrack("3",
                 VideoTrackViewState(screenTrack))
         participantManager.changePinnedParticipant(localParticipant.sid)
 
         inOrder(screenTrack).run {
-            verify(screenTrack).priority = TrackPriority.HIGH
+            verify(screenTrack).priority = HIGH
             verify(screenTrack).priority = null
         }
     }


### PR DESCRIPTION
## Description

https://issues.corp.twilio.com/browse/AHOYAPPS-703

Fixed an issue where the track priority is cleared on a participant when they are re rendered in the main view.

## Breakdown

- Check if the new participant is the same as the old primary participant in the `setTrackPriority()` function.
- Increased Gradle JVM heap to allow building release variants without running into OOM exceptions

## Validation

- Passed CI
- Manually validated on a Pixel XL

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
