### PR TITLE
AHOYAPPS-702: Fix screen share display bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,12 +161,25 @@ jobs:
       - attach_workspace:
           at: *workspace
       - run: *gcloud-auth
-      # Execute tests
       - run:
-          name: UI Tests
+          name: E2E Tests
           command: >
             gcloud firebase test android run --use-orchestrator --environment-variables clearPackageData=true --project video-app-79418
             ui-test-args.yaml:e2e-tests
+
+  integration-tests:
+    <<: *ui-test-defaults
+    steps:
+      # Setup
+      - checkout
+      - attach_workspace:
+          at: *workspace
+      - run: *gcloud-auth
+      - run:
+          name: Integration Tests
+          command: >
+            gcloud firebase test android run --use-orchestrator --environment-variables clearPackageData=true --project video-app-79418
+            ui-test-args.yaml:integration-tests
 
   build-release-app:
     <<: *build-defaults
@@ -230,6 +243,12 @@ workflows:
             - lint
             - check-format
       - e2e-tests:
+          <<: *build-test-filter
+          requires:
+            - build-app
+            - lint
+            - check-format
+      - integration-tests:
           <<: *build-test-filter
           requires:
             - build-app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
           command: ./gradlew app:testCommunityDebugUnitTest
       - save-cache: *save-cache-gradle
 
-  ui-tests:
+  e2e-tests:
     <<: *ui-test-defaults
     steps:
       # Setup
@@ -166,7 +166,7 @@ jobs:
           name: UI Tests
           command: >
             gcloud firebase test android run --use-orchestrator --environment-variables clearPackageData=true --project video-app-79418
-            ui-test-args.yaml:ui-tests
+            ui-test-args.yaml:e2e-tests
 
   build-release-app:
     <<: *build-defaults
@@ -229,7 +229,7 @@ workflows:
             - build-app
             - lint
             - check-format
-      - ui-tests:
+      - e2e-tests:
           <<: *build-test-filter
           requires:
             - build-app

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/AppLinkRoomTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/AppLinkRoomTest.kt
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
+@E2ETest
 class AppLinkRoomTest {
 
     @get:Rule

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/BackgroundSupportTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/BackgroundSupportTest.kt
@@ -14,9 +14,9 @@ import com.twilio.video.app.screen.clickJoinRoomButton
 import com.twilio.video.app.screen.enterRoomName
 import com.twilio.video.app.ui.splash.SplashActivity
 import com.twilio.video.app.util.getString
+import com.twilio.video.app.util.randomUUID
 import com.twilio.video.app.util.retryEspressoAction
 import com.twilio.video.app.util.uiDevice
-import java.util.UUID
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -32,7 +32,7 @@ class BackgroundSupportTest : BaseE2ETest() {
     fun it_should_show_a_notification_when_the_app_is_in_the_background() {
         retryEspressoAction { assertScreenIsDisplayed() }
 
-        enterRoomName(UUID.randomUUID().toString())
+        enterRoomName(randomUUID())
         clickJoinRoomButton()
 
         retryEspressoAction { assertRoomIsConnected() }

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/BackgroundSupportTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/BackgroundSupportTest.kt
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
-class BackgroundSupportTest : BaseUITest() {
+class BackgroundSupportTest : BaseE2ETest() {
 
     @get:Rule
     var scenario = activityScenarioRule<SplashActivity>()

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/BaseE2ETest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/BaseE2ETest.kt
@@ -6,7 +6,8 @@ import com.twilio.video.app.util.retrieveEmailCredentials
 import org.junit.Before
 import org.junit.Rule
 
-open class BaseUITest {
+@E2ETest
+open class BaseE2ETest {
 
     @get:Rule
     var permissionRule = GrantPermissionRule.grant(android.Manifest.permission.CAMERA,

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/E2ETest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/E2ETest.kt
@@ -1,0 +1,3 @@
+package com.twilio.video.app.e2eTest
+
+annotation class E2ETest

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/LoginTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/LoginTest.kt
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
+@E2ETest
 class LoginTest {
 
     @get:Rule

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/PermissionTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/PermissionTest.kt
@@ -15,6 +15,7 @@ import com.twilio.video.app.util.uiDevice
 import org.junit.Rule
 import org.junit.Test
 
+@E2ETest
 class PermissionTest {
 
     @get:Rule

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/PreferencesTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/PreferencesTest.kt
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
-class PreferencesTest : BaseUITest() {
+class PreferencesTest : BaseE2ETest() {
 
     @get:Rule
     var scenario = activityScenarioRule<SplashActivity>()

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/RoomTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/RoomTest.kt
@@ -11,8 +11,8 @@ import com.twilio.video.app.screen.clickMicButton
 import com.twilio.video.app.screen.clickVideoButton
 import com.twilio.video.app.screen.enterRoomName
 import com.twilio.video.app.ui.splash.SplashActivity
+import com.twilio.video.app.util.randomUUID
 import com.twilio.video.app.util.retryEspressoAction
-import java.util.UUID
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -34,7 +34,7 @@ class RoomTest : BaseE2ETest() {
 
     @Test
     fun it_should_connect_to_a_room_successfully() {
-        enterRoomName(UUID.randomUUID().toString())
+        enterRoomName(randomUUID())
         clickJoinRoomButton()
 
         retryEspressoAction { assertRoomIsConnected() }
@@ -46,7 +46,7 @@ class RoomTest : BaseE2ETest() {
     fun it_should_connect_to_a_room_successfully_with_mic_and_video_muted() {
         clickVideoButton()
         clickMicButton()
-        enterRoomName(UUID.randomUUID().toString())
+        enterRoomName(randomUUID())
         clickJoinRoomButton()
 
         retryEspressoAction { assertRoomIsConnected() }

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/RoomTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/RoomTest.kt
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
-class RoomTest : BaseUITest() {
+class RoomTest : BaseE2ETest() {
 
     @get:Rule
     var scenario = activityScenarioRule<SplashActivity>()

--- a/app/src/androidTest/java/com/twilio/video/app/integrationTest/IntegrationTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/integrationTest/IntegrationTest.kt
@@ -1,0 +1,3 @@
+package com.twilio.video.app.integrationTest
+
+annotation class IntegrationTest

--- a/app/src/androidTest/java/com/twilio/video/app/integrationTest/SettingsTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/integrationTest/SettingsTest.kt
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @MediumTest
+@IntegrationTest
 class SettingsTest {
 
     @get:Rule

--- a/app/src/androidTest/java/com/twilio/video/app/util/TestUtil.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/util/TestUtil.kt
@@ -8,6 +8,7 @@ import com.google.gson.stream.JsonReader
 import com.twilio.video.app.EmailCredentials
 import com.twilio.video.app.TestCredentials
 import java.io.InputStreamReader
+import java.util.UUID
 import java.util.concurrent.TimeoutException
 import junit.framework.AssertionFailedError
 
@@ -38,6 +39,8 @@ fun retrieveEmailCredentials(): EmailCredentials {
     val jsonReader = JsonReader(reader)
     return (Gson().fromJson(jsonReader, TestCredentials::class.java) as TestCredentials).email_sign_in_user
 }
+
+fun randomUUID() = UUID.randomUUID().toString()
 
 private fun countDown(startTime: Long): Long {
     Thread.sleep(10)

--- a/app/src/main/java/com/twilio/video/app/ui/room/ParticipantViewHolder.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/ParticipantViewHolder.kt
@@ -61,7 +61,8 @@ internal class ParticipantViewHolder(private val thumb: ParticipantThumbView) :
         if (videoTrackViewState?.let { it.isSwitchedOff } == true) {
             setState(ParticipantView.State.SWITCHED_OFF)
         } else {
-            setState(ParticipantView.State.VIDEO)
+            videoTrackViewState?.videoTrack?.let { setState(ParticipantView.State.VIDEO) }
+                    ?: setState(ParticipantView.State.NO_VIDEO)
         }
     }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/PrimaryParticipantController.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/PrimaryParticipantController.kt
@@ -50,9 +50,8 @@ internal class PrimaryParticipantController(
         primaryView.setMuted(newItem.muted)
         primaryView.setMirror(mirror)
         newItem.videoTrack?.let { newVideoTrack ->
-            removeRender(newVideoTrack, primaryView)
-            primaryView.setState(ParticipantView.State.VIDEO)
             newVideoTrack.addRenderer(primaryView)
+            primaryView.setState(ParticipantView.State.VIDEO)
         } ?: primaryView.setState(ParticipantView.State.NO_VIDEO)
     }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -1068,8 +1068,8 @@ public class RoomActivity extends BaseActivity {
             primaryParticipantController.renderAsPrimary(
                     primaryParticipant.getSid(),
                     primaryParticipant.getIdentity(),
-                    primaryParticipant.getVideoTrack(),
                     primaryParticipant.getScreenTrack(),
+                    primaryParticipant.getVideoTrack(),
                     primaryParticipant.isMuted(),
                     primaryParticipant.isMirrored());
         } else {

--- a/ui-test-args.yaml
+++ b/ui-test-args.yaml
@@ -1,4 +1,4 @@
-ui-tests:
+e2e-tests:
   timeout: 30m
   type: instrumentation
   app: app/build/outputs/apk/internal/debug/app-internal-debug.apk

--- a/ui-test-args.yaml
+++ b/ui-test-args.yaml
@@ -6,3 +6,16 @@ e2e-tests:
   device:
     - {model: lucye, version: 24}
     - {model: blueline, version: 29}
+  test-targets:
+    - "annotation com.twilio.video.app.e2eTest.E2ETest"
+
+integration-tests:
+  timeout: 30m
+  type: instrumentation
+  app: app/build/outputs/apk/internal/debug/app-internal-debug.apk
+  test: app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk
+  device:
+    - {model: lucye, version: 24}
+    - {model: blueline, version: 29}
+  test-targets:
+    - "annotation com.twilio.video.app.integrationTest.IntegrationTest"


### PR DESCRIPTION
## Description

Fixed a bug where a remote screen share track is not displayed in the main participant view. Also fixed another bug where a muted remote video track renders a frozen frame opposed to the correct NO_VIDEO thumbnail view state. The integration instrumentation tests are now separated from the E2E tests and are run as a separate CI jobs and separate FTL test runs.

## Breakdown

- Changed video track parameters to the correct order when calling the renderAsPrimary() function from the RoomActivity 
- Added additional null check to the setVideoState() extension function top render the NO_VIDEO view state
- Added e2e-tests and instrumentation-tests as separate FTL test runs and separate CI jobs
- Added E2ETest and IntegrationTest annotation classes to target the tests in FTL test runs

## Validation

- [Bulleted summary of validation steps]
- [eg. Add new unit tests to validate changes]
- [eg. Verified all CI checks pass on the feature branch]

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
