### PR TITLE
AHOYAPPS-730 Update video view scale type to aspect fit

### DIFF
--- a/app/src/main/java/com/twilio/video/app/ui/room/ParticipantView.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/ParticipantView.java
@@ -43,10 +43,12 @@ import java.lang.annotation.RetentionPolicy;
 
 abstract class ParticipantView extends FrameLayout implements VideoRenderer {
 
+    private static final VideoScaleType DEFAULT_VIDEO_SCALE_TYPE = VideoScaleType.ASPECT_FIT;
+
     String identity = "";
     int state = State.NO_VIDEO;
     boolean mirror = false;
-    int scaleType = VideoScaleType.ASPECT_BALANCED.ordinal();
+    int scaleType = DEFAULT_VIDEO_SCALE_TYPE.ordinal();
 
     VideoTrack videoTrack;
 
@@ -189,7 +191,7 @@ abstract class ParticipantView extends FrameLayout implements VideoRenderer {
             scaleType =
                     stylables.getInt(
                             R.styleable.ParticipantView_type,
-                            VideoScaleType.ASPECT_BALANCED.ordinal());
+                            DEFAULT_VIDEO_SCALE_TYPE.ordinal());
 
             stylables.recycle();
         }

--- a/app/src/main/java/com/twilio/video/app/ui/room/ParticipantView.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/ParticipantView.java
@@ -190,8 +190,7 @@ abstract class ParticipantView extends FrameLayout implements VideoRenderer {
             // obtain scale type
             scaleType =
                     stylables.getInt(
-                            R.styleable.ParticipantView_type,
-                            DEFAULT_VIDEO_SCALE_TYPE.ordinal());
+                            R.styleable.ParticipantView_type, DEFAULT_VIDEO_SCALE_TYPE.ordinal());
 
             stylables.recycle();
         }

--- a/app/src/main/res/layout/participant_view.xml
+++ b/app/src/main/res/layout/participant_view.xml
@@ -11,14 +11,18 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/participant_video_layout"
+        android:background="@color/participantSelectedBackground"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
         <com.twilio.video.VideoTextureView
             android:id="@+id/participant_video"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:overlaySurface="true"/>
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
 
         <View
             android:id="@+id/participant_track_switch_off_background"

--- a/app/src/main/res/layout/participant_view_primary.xml
+++ b/app/src/main/res/layout/participant_view_primary.xml
@@ -9,15 +9,18 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/participant_video_layout"
+        android:background="@color/participantSelectedBackground"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
         <com.twilio.video.VideoTextureView
             android:id="@+id/participant_video"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:overlaySurface="false"/>
-
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
 
         <TextView
             android:id="@+id/participant_video_identity"


### PR DESCRIPTION
## Description

Update scale type to aspect fit

## Breakdown

- Change the VideoTextureView to layout width and height to `wrap_content`
- Set the default scale type to ASPECT_FIT

## Validation

- Manual validation between 3 participants with desktop participant sharing screen. (See attached screenshots.

![device-2020-06-15-122943](https://user-images.githubusercontent.com/1734140/84687910-11b49a00-af04-11ea-9770-675603fa1b50.png)


## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
