### PR TITLE
AHOYAPPS-696: Fix permission crash when toggling local camera video

### DIFF
--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/PermissionTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/PermissionTest.kt
@@ -1,14 +1,16 @@
 package com.twilio.video.app.e2eTest
 
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.rule.GrantPermissionRule
-import com.twilio.video.app.HiddenView
-import com.twilio.video.app.R
+import com.twilio.video.app.screen.assertMicButtonIsDisabled
+import com.twilio.video.app.screen.assertMicButtonIsEnabled
+import com.twilio.video.app.screen.assertParticipantStubIsHidden
+import com.twilio.video.app.screen.assertVideoButtonIsDisabled
+import com.twilio.video.app.screen.assertVideoButtonIsEnabled
 import com.twilio.video.app.screen.loginWithEmail
 import com.twilio.video.app.ui.splash.SplashActivity
 import com.twilio.video.app.util.allowAllPermissions
+import com.twilio.video.app.util.denyAllPermissions
 import com.twilio.video.app.util.retrieveEmailCredentials
 import com.twilio.video.app.util.retryEspressoAction
 import com.twilio.video.app.util.uiDevice
@@ -33,7 +35,20 @@ class PermissionTest {
             allowAllPermissions()
         }
 
-        retryEspressoAction { onView(withId(R.id.participant_stub_image))
-                .check(HiddenView()) }
+        retryEspressoAction { assertParticipantStubIsHidden() }
+        assertVideoButtonIsEnabled()
+        assertMicButtonIsEnabled()
+    }
+
+    @Test
+    fun `it_should_display_disabled_mic_and_camera_buttons_when_permissions_are_denied`() {
+        loginWithEmail(retrieveEmailCredentials())
+
+        uiDevice().run {
+            denyAllPermissions()
+        }
+
+        retryEspressoAction { assertVideoButtonIsDisabled() }
+        assertMicButtonIsDisabled()
     }
 }

--- a/app/src/androidTest/java/com/twilio/video/app/screen/LobbyScreen.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/screen/LobbyScreen.kt
@@ -7,11 +7,14 @@ import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.hasChildCount
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.twilio.video.app.HiddenView
 import com.twilio.video.app.R
 import com.twilio.video.app.util.getString
 import com.twilio.video.app.util.getTargetContext
+import org.hamcrest.CoreMatchers.not
 
 fun assertScreenIsDisplayed() {
     onView(withText(getString(R.string.join))).check(matches(isDisplayed()))
@@ -48,4 +51,25 @@ fun assertRoomIsConnected() {
 
 fun clickDisconnectButton() {
     onView(withId(R.id.disconnect)).perform(click())
+}
+
+fun assertParticipantStubIsHidden() {
+    onView(withId(R.id.participant_stub_image))
+        .check(HiddenView())
+}
+
+fun assertVideoButtonIsDisabled() {
+    onView(withId(R.id.local_video_image_button)).check(matches(not(isEnabled())))
+}
+
+fun assertMicButtonIsDisabled() {
+    onView(withId(R.id.local_audio_image_button)).check(matches(not(isEnabled())))
+}
+
+fun assertVideoButtonIsEnabled() {
+    onView(withId(R.id.local_video_image_button)).check(matches(isEnabled()))
+}
+
+fun assertMicButtonIsEnabled() {
+    onView(withId(R.id.local_audio_image_button)).check(matches(isEnabled()))
 }

--- a/app/src/androidTest/java/com/twilio/video/app/screen/LobbyScreen.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/screen/LobbyScreen.kt
@@ -17,7 +17,9 @@ import com.twilio.video.app.util.getTargetContext
 import org.hamcrest.CoreMatchers.not
 
 fun assertScreenIsDisplayed() {
-    onView(withText(getString(R.string.join))).check(matches(isDisplayed()))
+    onView(withText(getString(R.string.join)))
+            .check(matches(isDisplayed()))
+            .check(matches(not(isEnabled())))
 }
 
 fun clickSettingsMenuItem() {

--- a/app/src/androidTest/java/com/twilio/video/app/util/UiAutomatorExtensions.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/util/UiAutomatorExtensions.kt
@@ -9,18 +9,23 @@ import java.util.concurrent.TimeoutException
 fun uiDevice(): UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
 fun UiDevice.allowAllPermissions() {
+    clickThroughDialogs("Allow|ALLOW")
+}
+
+fun UiDevice.denyAllPermissions() {
+    clickThroughDialogs("Deny|DENY")
+}
+
+private fun UiDevice.clickThroughDialogs(text: String) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        var allowPermissions = findText("Allow|ALLOW")
+        var allowPermissions = findObject(UiSelector().textMatches(text))
         if (allowPermissions.waitForExists(5000)) {
             while (allowPermissions.exists()) {
                 allowPermissions.click()
-                allowPermissions = findText("Allow|ALLOW")
+                allowPermissions = findObject(UiSelector().textMatches(text))
             }
         } else {
             throw TimeoutException("Timed out while waiting for permission dialog.")
         }
     }
 }
-
-private fun UiDevice.findText(text: String) =
-        findObject(UiSelector().textMatches(text))

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -93,6 +93,7 @@ import com.twilio.video.app.ui.room.RoomViewEffect.Disconnected;
 import com.twilio.video.app.ui.room.RoomViewEffect.ShowConnectFailureDialog;
 import com.twilio.video.app.ui.room.RoomViewEffect.ShowTokenErrorDialog;
 import com.twilio.video.app.ui.room.RoomViewEvent.ActivateAudioDevice;
+import com.twilio.video.app.ui.room.RoomViewEvent.CheckLocalMedia;
 import com.twilio.video.app.ui.room.RoomViewEvent.Disconnect;
 import com.twilio.video.app.ui.room.RoomViewEvent.RefreshViewState;
 import com.twilio.video.app.ui.room.RoomViewEvent.ScreenTrackRemoved;
@@ -322,6 +323,7 @@ public class RoomActivity extends BaseActivity {
         restoreCameraTrack();
 
         roomViewModel.processInput(RefreshViewState.INSTANCE);
+        roomViewModel.processInput(CheckLocalMedia.INSTANCE);
 
         publishLocalTracks();
 
@@ -387,7 +389,7 @@ public class RoomActivity extends BaseActivity {
                             && writeExternalStoragePermissionGranted;
 
             if (permissionsGranted) {
-                roomViewModel.processInput(RefreshViewState.INSTANCE);
+                roomViewModel.processInput(CheckLocalMedia.INSTANCE);
                 setupLocalMedia();
             } else {
                 Snackbar.make(primaryVideoView, R.string.permissions_required, Snackbar.LENGTH_LONG)
@@ -796,14 +798,15 @@ public class RoomActivity extends BaseActivity {
 
         boolean isMicEnabled = roomViewState.isMicEnabled();
         boolean isCameraEnabled = roomViewState.isCameraEnabled();
-        localAudioImageButton.setEnabled(isMicEnabled);
-        localVideoImageButton.setEnabled(isCameraEnabled);
+        boolean isLocalMediaEnabled = isMicEnabled && isCameraEnabled;
+        localAudioImageButton.setEnabled(isLocalMediaEnabled);
+        localVideoImageButton.setEnabled(isLocalMediaEnabled);
         int micDrawable =
-                isAudioMuted || !isMicEnabled
+                isAudioMuted || !isLocalMediaEnabled
                         ? R.drawable.ic_mic_off_gray_24px
                         : R.drawable.ic_mic_white_24px;
         int videoDrawable =
-                isVideoMuted || !isCameraEnabled
+                isVideoMuted || !isLocalMediaEnabled
                         ? R.drawable.ic_videocam_off_gray_24px
                         : R.drawable.ic_videocam_white_24px;
         localAudioImageButton.setImageResource(micDrawable);

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -757,7 +757,8 @@ public class RoomActivity extends BaseActivity {
         boolean screenCaptureMenuItemState = false;
 
         Editable roomEditable = roomEditText.getText();
-        boolean connectButtonEnabled = roomEditable != null && !roomEditable.toString().isEmpty();
+        boolean isRoomTextNotEmpty = roomEditable != null && !roomEditable.toString().isEmpty();
+        boolean connectButtonEnabled = isRoomTextNotEmpty;
 
         String roomName = displayName;
         String toolbarTitle = displayName;
@@ -792,7 +793,7 @@ public class RoomActivity extends BaseActivity {
             joinStatus = "";
         }
         if (roomViewState.isLobbyLayoutVisible()) {
-            connectButtonEnabled = true;
+            connectButtonEnabled = isRoomTextNotEmpty;
             screenCaptureMenuItemState = false;
         }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -794,15 +794,20 @@ public class RoomActivity extends BaseActivity {
             screenCaptureMenuItemState = false;
         }
 
-        // Check mute state
-        if (isAudioMuted) {
-            localAudioImageButton.setImageResource(R.drawable.ic_mic_off_gray_24px);
-        }
-        if (isVideoMuted) {
-            localVideoImageButton.setImageResource(R.drawable.ic_videocam_off_gray_24px);
-        }
-        localAudioImageButton.setEnabled(roomViewState.isMicEnabled());
-        localVideoImageButton.setEnabled(roomViewState.isCameraEnabled());
+        boolean isMicEnabled = roomViewState.isMicEnabled();
+        boolean isCameraEnabled = roomViewState.isCameraEnabled();
+        localAudioImageButton.setEnabled(isMicEnabled);
+        localVideoImageButton.setEnabled(isCameraEnabled);
+        int micDrawable =
+                isAudioMuted || !isMicEnabled
+                        ? R.drawable.ic_mic_off_gray_24px
+                        : R.drawable.ic_mic_white_24px;
+        int videoDrawable =
+                isVideoMuted || !isCameraEnabled
+                        ? R.drawable.ic_videocam_off_gray_24px
+                        : R.drawable.ic_videocam_white_24px;
+        localAudioImageButton.setImageResource(micDrawable);
+        localVideoImageButton.setImageResource(videoDrawable);
 
         statsListAdapter = new StatsListAdapter(this);
         statsRecyclerView.setAdapter(statsListAdapter);

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -93,7 +93,7 @@ import com.twilio.video.app.ui.room.RoomViewEffect.Disconnected;
 import com.twilio.video.app.ui.room.RoomViewEffect.ShowConnectFailureDialog;
 import com.twilio.video.app.ui.room.RoomViewEffect.ShowTokenErrorDialog;
 import com.twilio.video.app.ui.room.RoomViewEvent.ActivateAudioDevice;
-import com.twilio.video.app.ui.room.RoomViewEvent.CheckLocalMedia;
+import com.twilio.video.app.ui.room.RoomViewEvent.CheckPermissions;
 import com.twilio.video.app.ui.room.RoomViewEvent.Disconnect;
 import com.twilio.video.app.ui.room.RoomViewEvent.RefreshViewState;
 import com.twilio.video.app.ui.room.RoomViewEvent.ScreenTrackRemoved;
@@ -323,7 +323,7 @@ public class RoomActivity extends BaseActivity {
         restoreCameraTrack();
 
         roomViewModel.processInput(RefreshViewState.INSTANCE);
-        roomViewModel.processInput(CheckLocalMedia.INSTANCE);
+        roomViewModel.processInput(CheckPermissions.INSTANCE);
 
         publishLocalTracks();
 
@@ -389,7 +389,7 @@ public class RoomActivity extends BaseActivity {
                             && writeExternalStoragePermissionGranted;
 
             if (permissionsGranted) {
-                roomViewModel.processInput(CheckLocalMedia.INSTANCE);
+                roomViewModel.processInput(CheckPermissions.INSTANCE);
                 setupLocalMedia();
             } else {
                 Snackbar.make(primaryVideoView, R.string.permissions_required, Snackbar.LENGTH_LONG)

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -596,6 +596,8 @@ public class RoomActivity extends BaseActivity {
                 cameraVideoTrack != null
                         ? R.drawable.ic_videocam_white_24px
                         : R.drawable.ic_videocam_off_gray_24px);
+
+        roomViewModel.processInput(RefreshViewState.INSTANCE);
     }
 
     private void publishVideoTrack(LocalVideoTrack videoTrack, TrackPriority trackPriority) {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -103,6 +103,7 @@ import com.twilio.video.app.ui.room.RoomViewModel.RoomViewModelFactory;
 import com.twilio.video.app.ui.settings.SettingsActivity;
 import com.twilio.video.app.util.CameraCapturerCompat;
 import com.twilio.video.app.util.InputUtils;
+import com.twilio.video.app.util.PermissionUtil;
 import com.twilio.video.app.util.StatsScheduler;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -266,7 +267,9 @@ public class RoomActivity extends BaseActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        RoomViewModelFactory factory = new RoomViewModelFactory(roomManager, audioDeviceSelector);
+        RoomViewModelFactory factory =
+                new RoomViewModelFactory(
+                        roomManager, audioDeviceSelector, new PermissionUtil(this));
         roomViewModel = new ViewModelProvider(this, factory).get(RoomViewModel.class);
 
         if (savedInstanceState != null) {
@@ -384,6 +387,7 @@ public class RoomActivity extends BaseActivity {
                             && writeExternalStoragePermissionGranted;
 
             if (permissionsGranted) {
+                roomViewModel.processInput(RefreshViewState.INSTANCE);
                 setupLocalMedia();
             } else {
                 Snackbar.make(primaryVideoView, R.string.permissions_required, Snackbar.LENGTH_LONG)
@@ -797,6 +801,8 @@ public class RoomActivity extends BaseActivity {
         if (isVideoMuted) {
             localVideoImageButton.setImageResource(R.drawable.ic_videocam_off_gray_24px);
         }
+        localAudioImageButton.setEnabled(roomViewState.isMicEnabled());
+        localVideoImageButton.setEnabled(roomViewState.isCameraEnabled());
 
         statsListAdapter = new StatsListAdapter(this);
         statsRecyclerView.setAdapter(statsListAdapter);

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewEffect.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewEffect.kt
@@ -5,6 +5,7 @@ import com.twilio.video.app.data.api.AuthServiceError
 
 sealed class RoomViewEffect {
 
+    object CheckLocalMedia : RoomViewEffect()
     // TODO Remove duplicated RoomEvents once all SDK code is decoupled from RoomActivity
     object Connecting : RoomViewEffect()
     data class Connected(val room: Room) : RoomViewEffect()

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewEvent.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewEvent.kt
@@ -4,6 +4,7 @@ import com.twilio.audioswitch.selection.AudioDevice
 
 sealed class RoomViewEvent {
     object RefreshViewState : RoomViewEvent()
+    object CheckLocalMedia : RoomViewEvent()
     data class SelectAudioDevice(val device: AudioDevice) : RoomViewEvent()
     object ActivateAudioDevice : RoomViewEvent()
     object DeactivateAudioDevice : RoomViewEvent()

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewEvent.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewEvent.kt
@@ -4,7 +4,7 @@ import com.twilio.audioswitch.selection.AudioDevice
 
 sealed class RoomViewEvent {
     object RefreshViewState : RoomViewEvent()
-    object CheckLocalMedia : RoomViewEvent()
+    object CheckPermissions : RoomViewEvent()
     data class SelectAudioDevice(val device: AudioDevice) : RoomViewEvent()
     object ActivateAudioDevice : RoomViewEvent()
     object DeactivateAudioDevice : RoomViewEvent()

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -29,6 +29,7 @@ import com.twilio.video.app.ui.room.RoomViewEffect.CheckLocalMedia
 import com.twilio.video.app.ui.room.RoomViewEffect.ShowConnectFailureDialog
 import com.twilio.video.app.ui.room.RoomViewEffect.ShowTokenErrorDialog
 import com.twilio.video.app.ui.room.RoomViewEvent.ActivateAudioDevice
+import com.twilio.video.app.ui.room.RoomViewEvent.CheckPermissions
 import com.twilio.video.app.ui.room.RoomViewEvent.Connect
 import com.twilio.video.app.ui.room.RoomViewEvent.DeactivateAudioDevice
 import com.twilio.video.app.ui.room.RoomViewEvent.Disconnect
@@ -86,7 +87,7 @@ class RoomViewModel(
         Timber.d("View Event: $viewEvent")
         when (viewEvent) {
             is RefreshViewState -> updateState { it.copy() }
-            is RoomViewEvent.CheckLocalMedia -> checkLocalMedia()
+            is CheckPermissions -> checkLocalMedia()
             is SelectAudioDevice -> {
                 audioDeviceSelector.selectDevice(viewEvent.device)
             }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -55,8 +55,9 @@ class RoomViewModel(
     private val participantManager: ParticipantManager = ParticipantManager(),
     private val backgroundScope: CoroutineScope = CoroutineScope(Dispatchers.IO),
     private val rxDisposables: CompositeDisposable = CompositeDisposable(),
-    scheduler: Scheduler = AndroidSchedulers.mainThread()
-) : BaseViewModel<RoomViewEvent, RoomViewState, RoomViewEffect>(RoomViewState()) {
+    scheduler: Scheduler = AndroidSchedulers.mainThread(),
+    initialViewState: RoomViewState = RoomViewState()
+) : BaseViewModel<RoomViewEvent, RoomViewState, RoomViewEffect>(initialViewState) {
 
     init {
         audioDeviceSelector.start { audioDevices, selectedDevice ->
@@ -118,7 +119,6 @@ class RoomViewModel(
         val isMicEnabled = permissionUtil.isPermissionGranted(Manifest.permission.RECORD_AUDIO)
 
         updateState { it.copy(isCameraEnabled = isCameraEnabled, isMicEnabled = isMicEnabled) }
-
         if (isCameraEnabled && isMicEnabled) viewEffect { CheckLocalMedia }
     }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -25,6 +25,7 @@ import com.twilio.video.app.ui.room.RoomEvent.ParticipantEvent.ScreenTrackUpdate
 import com.twilio.video.app.ui.room.RoomEvent.ParticipantEvent.TrackSwitchOff
 import com.twilio.video.app.ui.room.RoomEvent.ParticipantEvent.VideoTrackUpdated
 import com.twilio.video.app.ui.room.RoomEvent.TokenError
+import com.twilio.video.app.ui.room.RoomViewEffect.CheckLocalMedia
 import com.twilio.video.app.ui.room.RoomViewEffect.ShowConnectFailureDialog
 import com.twilio.video.app.ui.room.RoomViewEffect.ShowTokenErrorDialog
 import com.twilio.video.app.ui.room.RoomViewEvent.ActivateAudioDevice
@@ -83,7 +84,8 @@ class RoomViewModel(
     override fun processInput(viewEvent: RoomViewEvent) {
         Timber.d("View Event: $viewEvent")
         when (viewEvent) {
-            is RefreshViewState -> checkCameraAndMicPermissions()
+            is RefreshViewState -> updateState { it.copy() }
+            is RoomViewEvent.CheckLocalMedia -> checkLocalMedia()
             is SelectAudioDevice -> {
                 audioDeviceSelector.selectDevice(viewEvent.device)
             }
@@ -111,11 +113,13 @@ class RoomViewModel(
         }
     }
 
-    private fun checkCameraAndMicPermissions() {
+    private fun checkLocalMedia() {
         val isCameraEnabled = permissionUtil.isPermissionGranted(Manifest.permission.CAMERA)
         val isMicEnabled = permissionUtil.isPermissionGranted(Manifest.permission.RECORD_AUDIO)
 
         updateState { it.copy(isCameraEnabled = isCameraEnabled, isMicEnabled = isMicEnabled) }
+
+        if (isCameraEnabled && isMicEnabled) viewEffect { CheckLocalMedia }
     }
 
     private fun observeRoomEvents(roomEvent: RoomEvent) {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewState.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewState.kt
@@ -12,6 +12,8 @@ data class RoomViewState(
     val isLobbyLayoutVisible: Boolean = true,
     val isConnectingLayoutVisible: Boolean = false,
     val isConnectedLayoutVisible: Boolean = false,
+    val isCameraEnabled: Boolean = false,
+    val isMicEnabled: Boolean = false,
     val isAudioMuted: Boolean = true,
     val isVideoMuted: Boolean = true
 )

--- a/app/src/main/java/com/twilio/video/app/util/PermissionUtil.kt
+++ b/app/src/main/java/com/twilio/video/app/util/PermissionUtil.kt
@@ -1,0 +1,11 @@
+package com.twilio.video.app.util
+
+import android.content.Context
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import androidx.core.content.ContextCompat.checkSelfPermission
+
+class PermissionUtil(private val context: Context) {
+
+    fun isPermissionGranted(permission: String) =
+            checkSelfPermission(context, permission) == PERMISSION_GRANTED
+}

--- a/app/src/test/java/com/twilio/video/app/ui/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/twilio/video/app/ui/room/RoomViewModelTest.kt
@@ -80,7 +80,7 @@ class RoomViewModelTest {
                 .thenReturn(true)
         val expectedViewState = RoomViewState(isCameraEnabled = true)
 
-        viewModel.processInput(RoomViewEvent.CheckLocalMedia)
+        viewModel.processInput(RoomViewEvent.CheckPermissions)
 
         assertThat(viewModel.viewState.value, equalTo(expectedViewState))
     }
@@ -98,7 +98,7 @@ class RoomViewModelTest {
                 .thenReturn(false)
         val expectedViewState = RoomViewState(isCameraEnabled = false)
 
-        viewModel.processInput(RoomViewEvent.CheckLocalMedia)
+        viewModel.processInput(RoomViewEvent.CheckPermissions)
 
         assertThat(viewModel.viewState.value, equalTo(expectedViewState))
         assertThat(viewModel.viewEffects.value, `is`(nullValue()))
@@ -110,7 +110,7 @@ class RoomViewModelTest {
                 .thenReturn(true)
         val expectedViewState = RoomViewState(isMicEnabled = true)
 
-        viewModel.processInput(RoomViewEvent.CheckLocalMedia)
+        viewModel.processInput(RoomViewEvent.CheckPermissions)
 
         assertThat(viewModel.viewState.value, equalTo(expectedViewState))
     }
@@ -128,7 +128,7 @@ class RoomViewModelTest {
                 .thenReturn(false)
         val expectedViewState = RoomViewState(isMicEnabled = false)
 
-        viewModel.processInput(RoomViewEvent.CheckLocalMedia)
+        viewModel.processInput(RoomViewEvent.CheckPermissions)
 
         assertThat(viewModel.viewState.value, equalTo(expectedViewState))
         assertThat(viewModel.viewEffects.value, `is`(nullValue()))
@@ -141,7 +141,7 @@ class RoomViewModelTest {
         whenever(permissionUtil.isPermissionGranted(Manifest.permission.RECORD_AUDIO))
                 .thenReturn(true)
 
-        viewModel.processInput(RoomViewEvent.CheckLocalMedia)
+        viewModel.processInput(RoomViewEvent.CheckPermissions)
 
         val expectedViewEffect = viewModel.viewEffects.value!!
                 .getContentIfNotHandled() is RoomViewEffect.CheckLocalMedia


### PR DESCRIPTION
## Description

https://issues.corp.twilio.com/browse/AHOYAPPS-696

This PR fixes a bug where the app crashes when a user toggles the local camera video after denying the camera permission. The following bugs are also fixed as part of this PR.

* Primary Video View freezes after muting video in the lobby.
* The join button is enabled with an empty room name.

## Breakdown

- Added a new RoomViewEvent, CheckLocalMedia, that checks the local media permission state
- Added new RoomViewState properties to track the permission state for local media
- Added PermissionUtil to handle permission state check

## Validation

- Passed CI Pipeline
- Manually tested on PixelXL

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
