### PR TITLE
AHOYAPPS-806: Add new passcode format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ aliases:
     docker:
       - image: circleci/android:api-28-node
     environment:
-      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
 
   - &ui-test-defaults
     working_directory: *workspace

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -180,7 +180,7 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"
     implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0'
-    implementation 'com.twilio:audioswitch:0.3.0'
+    implementation 'com.twilio:audioswitch:0.4.0'
 
     internalImplementation "com.microsoft.appcenter:appcenter-distribute:2.5.1"
 

--- a/app/src/main/java/com/twilio/video/app/AudioSwitchModule.kt
+++ b/app/src/main/java/com/twilio/video/app/AudioSwitchModule.kt
@@ -9,6 +9,6 @@ import dagger.Provides
 class AudioSwitchModule {
 
     @Provides
-    fun providesAudioSwitch(application: Application): AudioSwitch =
-            AudioSwitch(application)
+    fun providesAudioDeviceSelector(application: Application): AudioSwitch =
+            AudioSwitch(application, loggingEnabled = true)
 }

--- a/app/src/testCommunity/java/com/twilio/video/app/data/api/AuthServiceRepositoryTest.kt
+++ b/app/src/testCommunity/java/com/twilio/video/app/data/api/AuthServiceRepositoryTest.kt
@@ -1,6 +1,8 @@
 package com.twilio.video.app.data.api
 
+import com.nhaarman.mockitokotlin2.isA
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import com.twilio.video.app.data.PASSCODE
 import com.twilio.video.app.security.SecurePreferences
@@ -23,8 +25,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-private const val passcode = "1234567890"
+private const val passcode = "12345678901234"
 private const val token = "token"
+private const val expectedURL = "https://video-app-7890-1234-dev.twil.io/token"
 
 @ExperimentalCoroutinesApi
 @RunWith(JUnitParamsRunner::class)
@@ -32,14 +35,14 @@ class AuthServiceRepositoryTest {
 
     @get:Rule
     var coroutineScope = MainCoroutineScopeRule()
-    private var expectedUrl = URL_PREFIX + passcode.substring(6) + URL_SUFFIX
     private var expectedRequestDTO = AuthServiceRequestDTO(passcode)
+    private var authService = mock<AuthService>()
 
     @Test
     fun `it should retrieve the passcode from SecurePreferences for a null passcode`() {
         coroutineScope.runBlockingTest {
-            val authService: AuthService = mock {
-                whenever(mock.getToken(expectedUrl, expectedRequestDTO))
+            authService = mock {
+                whenever(mock.getToken(isA(), isA()))
                         .thenReturn(AuthServiceResponseDTO(token))
             }
             val securePreferences = mock<SecurePreferences> {
@@ -49,6 +52,7 @@ class AuthServiceRepositoryTest {
 
             val actualToken = repository.getToken()
 
+            verify(authService).getToken(expectedURL, expectedRequestDTO)
             assertThat(actualToken, equalTo(token))
         }
     }
@@ -62,16 +66,88 @@ class AuthServiceRepositoryTest {
     }
 
     @Test
-    fun `it should return a token if the request is successful`() {
+    fun `it should return a token for a valid passcode size`() {
         coroutineScope.runBlockingTest {
-            val authService: AuthService = mock {
-                whenever(mock.getToken(expectedUrl, expectedRequestDTO))
-                        .thenReturn(AuthServiceResponseDTO(token))
-            }
-            val repository = AuthServiceRepository(authService, mock())
+            val repository = setupRepository()
             val actualToken = repository.getToken(passcode = passcode)
 
+            verify(authService).getToken(expectedURL, expectedRequestDTO)
             assertThat(actualToken, equalTo(token))
+        }
+    }
+
+    @Test
+    fun `it should return a token for a valid legacy passcode size`() {
+        coroutineScope.runBlockingTest {
+            val passcode = "1234567890"
+            val legacyURL = "https://video-app-7890-dev.twil.io/token"
+            val repository = setupRepository()
+            val actualToken = repository.getToken(passcode = passcode)
+
+            verify(authService).getToken(legacyURL, expectedRequestDTO.copy(passcode = passcode))
+            assertThat(actualToken, equalTo(token))
+        }
+    }
+
+    fun illegalArgParams(): Array<String?> {
+        return arrayOf(
+                "",
+                "123456789",
+                "12345678901",
+                "123456789012",
+                "1234567890123",
+                "123456789012345"
+        )
+    }
+
+    @Parameters(method = "illegalArgParams")
+    @Test(expected = IllegalArgumentException::class)
+    fun `it should throw an IllegalArgumentException for an invalid passcode`(passcode: String?) {
+        coroutineScope.runBlockingTest {
+            val repository = setupRepository()
+            repository.getToken(passcode = passcode)
+        }
+    }
+
+    fun authServiceExceptionParams(): Array<AuthService> {
+        var parameters = arrayOf<AuthService>()
+
+        coroutineScope.runBlockingTest {
+
+            val nullToken: AuthService = mock {
+                whenever(mock.getToken(isA(), isA()))
+                        .thenReturn(AuthServiceResponseDTO())
+            }
+
+            val nullResponse: AuthService = getMockAuthService()
+            val invalidJson: AuthService = getMockAuthService("Bad format!")
+            val nullErrorBody: AuthService = getMockAuthService("{}")
+            val nullErrorDTO: AuthService = getMockAuthService("")
+            val unknownErrorType: AuthService = getMockAuthService(UNKNOWN_ERROR_MESSAGE)
+
+            parameters =
+                    arrayOf(nullToken,
+                            nullResponse,
+                            invalidJson,
+                            nullErrorBody,
+                            nullErrorDTO,
+                            unknownErrorType)
+        }
+
+        return parameters
+    }
+
+    @Parameters(method = "authServiceExceptionParams")
+    @Test
+    fun `it should throw an AuthServiceException with no error type`(authService: AuthService) {
+        coroutineScope.runBlockingTest {
+            val repository = AuthServiceRepository(authService, mock())
+            try {
+                repository.getToken(passcode = passcode)
+                fail("Exception was never thrown!")
+            } catch (e: AuthServiceException) {
+                assertThat(e.error, `is`(nullValue()))
+            }
         }
     }
 
@@ -85,13 +161,10 @@ class AuthServiceRepositoryTest {
                     userIdentity,
                     roomName
             )
-            val authService: AuthService = mock {
-                whenever(mock.getToken(expectedUrl, expectedRequestDTO))
-                        .thenReturn(AuthServiceResponseDTO(token))
-            }
-            val repository = AuthServiceRepository(authService, mock())
+            val repository = setupRepository()
             val actualToken = repository.getToken(userIdentity, roomName, passcode)
 
+            verify(authService).getToken(expectedURL, expectedRequestDTO)
             assertThat(actualToken, equalTo(token))
         }
     }
@@ -100,8 +173,8 @@ class AuthServiceRepositoryTest {
     fun `it should throw an AuthServiceException with error type INVALID_PASSCODE_ERROR if the passcode is invalid`() {
         coroutineScope.runBlockingTest {
             val exception = getMockHttpException(INVALID_PASSCODE_ERROR)
-            val authService: AuthService = mock {
-                whenever(mock.getToken(expectedUrl, expectedRequestDTO))
+            authService = mock {
+                whenever(mock.getToken(isA(), isA()))
                         .thenThrow(exception)
             }
             val repository = AuthServiceRepository(authService, mock())
@@ -119,8 +192,8 @@ class AuthServiceRepositoryTest {
     fun `it should throw an AuthServiceException with error type EXPIRED_PASSCODE_ERROR if the passcode is expired`() {
         coroutineScope.runBlockingTest {
             val exception = getMockHttpException(EXPIRED_PASSCODE_ERROR)
-            val authService: AuthService = mock {
-                whenever(mock.getToken(expectedUrl, expectedRequestDTO))
+            authService = mock {
+                whenever(mock.getToken(isA(), isA()))
                         .thenThrow(exception)
             }
             val repository = AuthServiceRepository(authService, mock())
@@ -134,54 +207,19 @@ class AuthServiceRepositoryTest {
         }
     }
 
-    fun authServiceExceptionParams(): Array<Array<AuthService>> {
-        var parameters = arrayOf(arrayOf<AuthService>())
-
-        coroutineScope.runBlockingTest {
-
-            val nullToken: AuthService = mock {
-                whenever(mock.getToken(expectedUrl, expectedRequestDTO))
-                        .thenReturn(AuthServiceResponseDTO())
-            }
-
-            val nullResponse: AuthService = getMockAuthService()
-            val invalidJson: AuthService = getMockAuthService("Bad format!")
-            val nullErrorBody: AuthService = getMockAuthService("{}")
-            val nullErrorDTO: AuthService = getMockAuthService("")
-            val unknownErrorType: AuthService = getMockAuthService(UNKNOWN_ERROR_MESSAGE)
-
-            parameters =
-                    arrayOf(
-                            arrayOf(nullToken),
-                            arrayOf(nullResponse),
-                            arrayOf(invalidJson),
-                            arrayOf(nullErrorBody),
-                            arrayOf(nullErrorDTO),
-                            arrayOf(unknownErrorType)
-                    )
+    private suspend fun setupRepository():
+            AuthServiceRepository {
+        authService = mock {
+            whenever(mock.getToken(isA(), isA()))
+                    .thenReturn(AuthServiceResponseDTO(token))
         }
-
-        return parameters
+        return AuthServiceRepository(authService, mock())
     }
 
     private suspend fun getMockAuthService(json: String? = null): AuthService =
             mock {
                 val exception = json?.let { getMockHttpException(it) } ?: mock()
-                whenever(mock.getToken(expectedUrl, expectedRequestDTO))
+                whenever(mock.getToken(isA(), isA()))
                         .thenThrow(exception)
             }
-
-    @Parameters(method = "authServiceExceptionParams")
-    @Test
-    fun `it should throw an AuthServiceException with no error type`(authService: AuthService) {
-        coroutineScope.runBlockingTest {
-            val repository = AuthServiceRepository(authService, mock())
-            try {
-                repository.getToken(passcode = passcode)
-                fail("Exception was never thrown!")
-            } catch (e: AuthServiceException) {
-                assertThat(e.error, `is`(nullValue()))
-            }
-        }
-    }
 }


### PR DESCRIPTION
### ⚠️ This change is required for compatibility with updated [token server](https://github.com/twilio/twilio-video-app-android#deploy-twilio-access-token-server)

1. Add support for longer passcode format. The old format only used 4 digits to generate the URL which was not unique enough and some customers were running into conflicts. The only difference from an end user perspective is the passcode is now 14 digits instead of 10.
1. This is still backwards compatible with the shorter passcode format.
1. Using the latest [token server](https://github.com/twilio/twilio-video-app-android#deploy-twilio-access-token-server) with older versions of the Android video app will produce an error when the user enters the passcode. The solution is to update to the latest version to include changes in this PR.

* Also updated AudioSwitch dependency to [0.4.0](https://github.com/twilio/audioswitch/releases/tag/0.4.0).