### PR TITLE
AHOYAPPS-829: Optimize for P2P

### DIFF
--- a/app/src/community/java/com/twilio/video/app/auth/CommunityAuthenticator.kt
+++ b/app/src/community/java/com/twilio/video/app/auth/CommunityAuthenticator.kt
@@ -17,6 +17,7 @@
 package com.twilio.video.app.auth
 
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import com.twilio.video.app.auth.CommunityLoginResult.CommunityLoginFailureResult
 import com.twilio.video.app.auth.CommunityLoginResult.CommunityLoginSuccessResult
 import com.twilio.video.app.data.PASSCODE
@@ -24,8 +25,6 @@ import com.twilio.video.app.data.Preferences.DISPLAY_NAME
 import com.twilio.video.app.data.api.AuthServiceException
 import com.twilio.video.app.data.api.TokenService
 import com.twilio.video.app.security.SecurePreferences
-import com.twilio.video.app.util.putString
-import com.twilio.video.app.util.remove
 import io.reactivex.Observable
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.Dispatchers
@@ -49,7 +48,7 @@ class CommunityAuthenticator constructor(
                 try {
                     tokenService.getToken(identity = loginEvent.identity, passcode = loginEvent.passcode)
 
-                    sharedPreferences.putString(DISPLAY_NAME, loginEvent.identity)
+                    sharedPreferences.edit { putString(DISPLAY_NAME, loginEvent.identity) }
                     securePreferences.putSecureString(PASSCODE, loginEvent.passcode)
 
                     CommunityLoginSuccessResult
@@ -68,7 +67,7 @@ class CommunityAuthenticator constructor(
     }
 
     override fun logout() {
-        sharedPreferences.remove(DISPLAY_NAME)
-        sharedPreferences.remove(PASSCODE)
+        sharedPreferences.edit { remove(DISPLAY_NAME) }
+        sharedPreferences.edit { remove(PASSCODE) }
     }
 }

--- a/app/src/community/java/com/twilio/video/app/data/AuthServiceModule.kt
+++ b/app/src/community/java/com/twilio/video/app/data/AuthServiceModule.kt
@@ -15,6 +15,8 @@
  */
 package com.twilio.video.app.data
 
+import android.content.SharedPreferences
+import com.twilio.video.app.android.SharedPreferencesWrapper
 import com.twilio.video.app.data.api.AuthService
 import com.twilio.video.app.data.api.AuthServiceRepository
 import com.twilio.video.app.data.api.TokenService
@@ -58,8 +60,9 @@ class AuthServiceModule {
     @Provides
     fun providesTokenService(
         authService: AuthService,
-        securePreferences: SecurePreferences
+        securePreferences: SecurePreferences,
+        sharedPreferences: SharedPreferences
     ): TokenService {
-        return AuthServiceRepository(authService, securePreferences)
+        return AuthServiceRepository(authService, securePreferences, SharedPreferencesWrapper(sharedPreferences))
     }
 }

--- a/app/src/community/java/com/twilio/video/app/data/api/AuthServiceRepository.kt
+++ b/app/src/community/java/com/twilio/video/app/data/api/AuthServiceRepository.kt
@@ -17,7 +17,15 @@ package com.twilio.video.app.data.api
 
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
+import com.twilio.video.Vp8Codec
+import com.twilio.video.app.android.SharedPreferencesWrapper
 import com.twilio.video.app.data.PASSCODE
+import com.twilio.video.app.data.Preferences.TOPOLOGY
+import com.twilio.video.app.data.Preferences.VIDEO_CODEC
+import com.twilio.video.app.data.Preferences.VP8_SIMULCAST
+import com.twilio.video.app.data.api.model.Topology.GROUP
+import com.twilio.video.app.data.api.model.Topology.GROUP_SMALL
+import com.twilio.video.app.data.api.model.Topology.PEER_TO_PEER
 import com.twilio.video.app.security.SecurePreferences
 import retrofit2.HttpException
 import timber.log.Timber
@@ -27,7 +35,8 @@ private const val PASSCODE_SIZE = 14
 
 class AuthServiceRepository(
     private val authService: AuthService,
-    private val securePreferences: SecurePreferences
+    private val securePreferences: SecurePreferences,
+    private val sharedPreferences: SharedPreferencesWrapper
 ) : TokenService {
     override suspend fun getToken(identity: String?, roomName: String?): String {
         return getToken(identity, roomName, passcode = null)
@@ -35,25 +44,12 @@ class AuthServiceRepository(
 
     override suspend fun getToken(identity: String?, roomName: String?, passcode: String?): String {
         getPasscode(passcode)?.let { passcode ->
-            val requestBody = AuthServiceRequestDTO(
-                    passcode,
-                    identity,
-                    roomName)
-            val appId = passcode.substring(6, 10)
-            val serverlessId = passcode.substring(10)
-            val url = if (passcode.length == PASSCODE_SIZE) {
-                "$URL_PREFIX$appId-$serverlessId$URL_SUFFIX"
-            } else {
-                "$URL_PREFIX$appId$URL_SUFFIX"
-            }
+            val (requestBody, url) = buildRequest(passcode, identity, roomName)
 
             try {
                 authService.getToken(url, requestBody).let { response ->
-                    response.token?.let { token ->
-                        Timber.d("Token returned from Twilio auth service: %s", response)
-                        return token
-                    }
-                    throw AuthServiceException(message = "Token cannot be null")
+                    return handleResponse(response)
+                            ?: throw AuthServiceException(message = "Token cannot be null")
                 }
             } catch (httpException: HttpException) {
                 handleException(httpException)
@@ -61,6 +57,49 @@ class AuthServiceRepository(
         }
 
         throw IllegalArgumentException("Passcode cannot be null")
+    }
+
+    private fun buildRequest(
+        passcode: String,
+        identity: String?,
+        roomName: String?
+    ): Pair<AuthServiceRequestDTO, String> {
+        val requestBody = AuthServiceRequestDTO(
+            passcode,
+            identity,
+            roomName)
+        val appId = passcode.substring(6, 10)
+        val serverlessId = passcode.substring(10)
+        val url = if (passcode.length == PASSCODE_SIZE) {
+            "$URL_PREFIX$appId-$serverlessId$URL_SUFFIX"
+        } else {
+            "$URL_PREFIX$appId$URL_SUFFIX"
+        }
+        return Pair(requestBody, url)
+    }
+
+    private fun handleResponse(response: AuthServiceResponseDTO): String? {
+        return response.token?.let { token ->
+            Timber.d("Response successfully retrieved from the Twilio auth service: %s",
+                    response)
+            response.topology?.let { serverTopology ->
+                val isTopologyChange =
+                        sharedPreferences.getString(TOPOLOGY, null) != serverTopology.value
+                if (isTopologyChange) {
+                    sharedPreferences.edit { putString(TOPOLOGY, serverTopology.value) }
+                    val enableSimulcast = when (serverTopology) {
+                        GROUP, GROUP_SMALL -> true
+                        PEER_TO_PEER -> false
+                    }
+                    Timber.d("Server topology has changed to %s. " +
+                            "Setting the codec to Vp8 with simulcast set to %s", serverTopology,
+                            enableSimulcast)
+                    sharedPreferences.edit { putString(VIDEO_CODEC, Vp8Codec.NAME) }
+                    sharedPreferences.edit { putBoolean(VP8_SIMULCAST, enableSimulcast) }
+                }
+            }
+            token
+        }
     }
 
     private fun getPasscode(passcode: String?): String? {

--- a/app/src/community/java/com/twilio/video/app/data/api/AuthServiceRepository.kt
+++ b/app/src/community/java/com/twilio/video/app/data/api/AuthServiceRepository.kt
@@ -91,9 +91,8 @@ class AuthServiceRepository(
                         GROUP, GROUP_SMALL -> true
                         PEER_TO_PEER -> false
                     }
-                    Timber.d("Server topology has changed to %s. " +
-                            "Setting the codec to Vp8 with simulcast set to %s", serverTopology,
-                            enableSimulcast)
+                    Timber.d("Server topology has changed to %s. Setting the codec to Vp8 with simulcast set to %s",
+                            serverTopology, enableSimulcast)
                     sharedPreferences.edit { putString(VIDEO_CODEC, Vp8Codec.NAME) }
                     sharedPreferences.edit { putBoolean(VP8_SIMULCAST, enableSimulcast) }
                 }

--- a/app/src/community/java/com/twilio/video/app/data/api/AuthServiceResponseDTO.kt
+++ b/app/src/community/java/com/twilio/video/app/data/api/AuthServiceResponseDTO.kt
@@ -1,5 +1,8 @@
 package com.twilio.video.app.data.api
 
+import com.google.gson.annotations.SerializedName
+
 data class AuthServiceResponseDTO(
-    val token: String? = null
+    val token: String? = null,
+    @SerializedName("room_type") val roomType: RoomType? = null
 )

--- a/app/src/community/java/com/twilio/video/app/data/api/AuthServiceResponseDTO.kt
+++ b/app/src/community/java/com/twilio/video/app/data/api/AuthServiceResponseDTO.kt
@@ -1,8 +1,9 @@
 package com.twilio.video.app.data.api
 
 import com.google.gson.annotations.SerializedName
+import com.twilio.video.app.data.api.model.Topology
 
 data class AuthServiceResponseDTO(
     val token: String? = null,
-    @SerializedName("room_type") val roomType: RoomType? = null
+    @SerializedName("room_type") val topology: Topology? = null
 )

--- a/app/src/community/java/com/twilio/video/app/data/api/RoomType.kt
+++ b/app/src/community/java/com/twilio/video/app/data/api/RoomType.kt
@@ -1,9 +1,0 @@
-package com.twilio.video.app.data.api
-
-import com.google.gson.annotations.SerializedName
-
-enum class RoomType {
-    @SerializedName("group") GROUP,
-    @SerializedName("group-small") GROUP_SMALL,
-    @SerializedName("peer-to-peer") PEER_TO_PEER
-}

--- a/app/src/community/java/com/twilio/video/app/data/api/RoomType.kt
+++ b/app/src/community/java/com/twilio/video/app/data/api/RoomType.kt
@@ -1,0 +1,9 @@
+package com.twilio.video.app.data.api
+
+import com.google.gson.annotations.SerializedName
+
+enum class RoomType {
+    @SerializedName("group") GROUP,
+    @SerializedName("group-small") GROUP_SMALL,
+    @SerializedName("peer-to-peer") PEER_TO_PEER
+}

--- a/app/src/main/java/com/twilio/video/app/android/SharedPreferencesWrapper.kt
+++ b/app/src/main/java/com/twilio/video/app/android/SharedPreferencesWrapper.kt
@@ -1,0 +1,12 @@
+package com.twilio.video.app.android
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+class SharedPreferencesWrapper(private val sharedPreferences: SharedPreferences) :
+    SharedPreferences by sharedPreferences {
+
+    fun edit(action: SharedPreferences.Editor.() -> Unit) {
+        sharedPreferences.edit(action = action)
+    }
+}

--- a/app/src/main/java/com/twilio/video/app/data/Preferences.kt
+++ b/app/src/main/java/com/twilio/video/app/data/Preferences.kt
@@ -30,7 +30,7 @@ object Preferences {
     const val ENVIRONMENT = "pref_environment"
     const val ENVIRONMENT_DEFAULT = BuildConfig.ENVIRONMENT_DEFAULT
     const val TOPOLOGY = "pref_topology"
-    val TOPOLOGY_DEFAULT: String = Topology.GROUP.string
+    val TOPOLOGY_DEFAULT: String = Topology.GROUP.value
     const val MIN_FPS = "pref_min_fps"
     const val MAX_FPS = "pref_max_fps"
     const val MIN_VIDEO_DIMENSIONS = "pref_min_video_dim"

--- a/app/src/main/java/com/twilio/video/app/data/Preferences.kt
+++ b/app/src/main/java/com/twilio/video/app/data/Preferences.kt
@@ -37,7 +37,6 @@ object Preferences {
     const val MAX_VIDEO_DIMENSIONS = "pref_max_video_dim"
     const val ASPECT_RATIO = "pref_aspect_ratio"
     const val VERSION_NAME = "pref_version_name"
-    const val VERSION_CODE = "pref_version_code"
     const val VIDEO_LIBRARY_VERSION = "pref_video_library_version"
     const val LOGOUT = "pref_logout"
     const val ENABLE_STATS = "pref_enable_stats"

--- a/app/src/main/java/com/twilio/video/app/data/api/model/Topology.kt
+++ b/app/src/main/java/com/twilio/video/app/data/api/model/Topology.kt
@@ -15,6 +15,16 @@
  */
 package com.twilio.video.app.data.api.model
 
-enum class Topology(val string: String) {
-    GROUP("group"), GROUP_SMALL("group-small"), P2P("peer-to-peer");
+import com.google.gson.annotations.SerializedName
+
+private const val GROUP_ROOM_NAME = "group"
+private const val GROUP_SMALL_ROOM_NAME = "group-small"
+private const val PEER_TO_PEER_ROOM_NAME = "peer-to-peer"
+
+enum class Topology(val value: String) {
+    @SerializedName(GROUP_ROOM_NAME) GROUP(GROUP_ROOM_NAME),
+    @SerializedName(GROUP_SMALL_ROOM_NAME) GROUP_SMALL(GROUP_SMALL_ROOM_NAME),
+    @SerializedName(PEER_TO_PEER_ROOM_NAME) PEER_TO_PEER(PEER_TO_PEER_ROOM_NAME);
+
+    override fun toString() = value
 }

--- a/app/src/main/java/com/twilio/video/app/ui/settings/InternalSettingsFragment.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/settings/InternalSettingsFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.preference.ListPreference
 import com.twilio.video.app.R
 import com.twilio.video.app.data.Preferences
+import com.twilio.video.app.data.api.model.Topology
 
 class InternalSettingsFragment : BaseSettingsFragment() {
 
@@ -16,6 +17,9 @@ class InternalSettingsFragment : BaseSettingsFragment() {
         }
 
         (findPreference(Preferences.TOPOLOGY) as ListPreference?)?.run {
+            val roomTypes = Topology.values().map { it.value }.toTypedArray()
+            entries = roomTypes
+            entryValues = roomTypes
             value = sharedPreferences.getString(Preferences.TOPOLOGY,
                     Preferences.TOPOLOGY_DEFAULT)
         }

--- a/app/src/main/java/com/twilio/video/app/util/SharedPreferencesExtensions.kt
+++ b/app/src/main/java/com/twilio/video/app/util/SharedPreferencesExtensions.kt
@@ -2,18 +2,6 @@ package com.twilio.video.app.util
 
 import android.content.SharedPreferences
 
-fun SharedPreferences.remove(key: String) {
-    edit()
-        .remove(key)
-        .apply()
-}
-
-fun SharedPreferences.putString(key: String, value: String) {
-    edit()
-        .putString(key, value)
-        .apply()
-}
-
 /*
  * Utility method that allows getting a shared preference with a default value. The return value
  * type is inferred by the default value type.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,11 +55,6 @@
         <item>dev</item>
     </string-array>
 
-    <string-array name="settings_screen_topology_array">
-        <item>group</item>
-        <item>group-small</item>
-        <item>peer-to-peer</item>
-    </string-array>
     <string-array name="settings_screen_aspect_ratio_array">
         <item>4:3</item>
         <item>16:9</item>

--- a/app/src/main/res/xml/internal_preferences.xml
+++ b/app/src/main/res/xml/internal_preferences.xml
@@ -11,8 +11,6 @@
         android:negativeButtonText="@null"
         app:iconSpaceReserved="false"/>
     <ListPreference
-        android:entries="@array/settings_screen_topology_array"
-        android:entryValues="@array/settings_screen_topology_array"
         android:key="pref_topology"
         android:summary="%s"
         android:title="@string/settings_screen_topology"

--- a/app/src/testCommunity/java/com/twilio/video/app/ui/login/CommunityLoginActivityTest.kt
+++ b/app/src/testCommunity/java/com/twilio/video/app/ui/login/CommunityLoginActivityTest.kt
@@ -12,6 +12,7 @@ import com.twilio.video.app.ApplicationModule
 import com.twilio.video.app.DaggerCommunityIntegrationTestComponent
 import com.twilio.video.app.R
 import com.twilio.video.app.TestApp
+import com.twilio.video.app.android.SharedPreferencesWrapper
 import com.twilio.video.app.auth.CommunityAuthModule
 import com.twilio.video.app.auth.CommunityAuthenticator
 import com.twilio.video.app.data.AuthServiceModule
@@ -71,14 +72,14 @@ class CommunityLoginActivityTest {
     private val preferences = PreferenceManager.getDefaultSharedPreferences(testApp)
     private val securePreferences = SecurePreferencesFake()
     private val authServiceRepository = AuthServiceRepository(authService,
-            securePreferences)
+            securePreferences, SharedPreferencesWrapper(preferences))
     private val securityModule: SecurityModule = mock {
         whenever(mock.providesSecurePreferences(any(), any())).thenReturn(securePreferences)
     }
     private val authServiceModule: AuthServiceModule = mock {
         whenever(mock.providesOkHttpClient()).thenReturn(mock())
         whenever(mock.providesAuthService(any())).thenReturn(authService)
-        whenever(mock.providesTokenService(any(), any())).thenReturn(authServiceRepository)
+        whenever(mock.providesTokenService(any(), any(), any())).thenReturn(authServiceRepository)
     }
     private val authenticator = CommunityAuthenticator(
             preferences,


### PR DESCRIPTION
## Description

This PR adds changes to the community `AuthServiceRepository` to now check the [token server](https://github.com/twilio-labs/plugin-rtc#token-server-api-documentation) room-type and set the preferred video codec for an optimized experience based on the type of room. The Vp8 video codec is configured for all room types, but simulcast is disabled for the peer-to-peer room type. 

**Note:** The video codec configuration can be changed in the advanced settings screen in the app, but keep in mind that the video codec will be changed automatically every time the app detects a room type change from the token server.

## Validation

- Passed CI.
- Manually validated that the codec changes are correct based on changes in room type from the token server.

## Additional Notes

Also made the following improvements:
1. Added a single source of truth for the Topology string values by only accessing them from the `Topology` class.
1. Replaced preferences editor extension functions with android ktx edit function.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
