### PR TITLE
Enable stats by default

### DIFF
--- a/app/src/main/java/com/twilio/video/app/adapter/StatsListAdapter.kt
+++ b/app/src/main/java/com/twilio/video/app/adapter/StatsListAdapter.kt
@@ -227,7 +227,7 @@ class StatsListAdapter(private val context: Context) : RecyclerView.Adapter<Stat
 
         handler.post {
             statsListItems.clear()
-            statsListItems.addAll(statsListItems.toList())
+            statsListItems.addAll(statsItemList.toList())
             notifyDataSetChanged()
         }
     }

--- a/app/src/main/java/com/twilio/video/app/data/Preferences.kt
+++ b/app/src/main/java/com/twilio/video/app/data/Preferences.kt
@@ -41,6 +41,7 @@ object Preferences {
     const val VIDEO_LIBRARY_VERSION = "pref_video_library_version"
     const val LOGOUT = "pref_logout"
     const val ENABLE_STATS = "pref_enable_stats"
+    const val ENABLE_STATS_DEFAULT = true
     const val ENABLE_INSIGHTS = "pref_enable_insights"
     const val ENABLE_NETWORK_QUALITY_LEVEL = "pref_enable_network_quality_level"
     const val ENABLE_NETWORK_QUALITY_LEVEL_DEFAULT = true

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -982,7 +982,7 @@ public class RoomActivity extends BaseActivity {
         if (statsScheduler.isRunning()) {
             statsScheduler.cancelStatsGathering();
         }
-        boolean enableStats = sharedPreferences.getBoolean(Preferences.ENABLE_STATS, false);
+        boolean enableStats = sharedPreferences.getBoolean(Preferences.ENABLE_STATS, Preferences.ENABLE_STATS_DEFAULT);
         if (enableStats && (room != null) && (room.getState() == CONNECTED)) {
             statsScheduler.scheduleStatsGathering(room, statsListener(), STATS_DELAY);
         }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.java
@@ -982,7 +982,9 @@ public class RoomActivity extends BaseActivity {
         if (statsScheduler.isRunning()) {
             statsScheduler.cancelStatsGathering();
         }
-        boolean enableStats = sharedPreferences.getBoolean(Preferences.ENABLE_STATS, Preferences.ENABLE_STATS_DEFAULT);
+        boolean enableStats =
+                sharedPreferences.getBoolean(
+                        Preferences.ENABLE_STATS, Preferences.ENABLE_STATS_DEFAULT);
         if (enableStats && (room != null) && (room.getState() == CONNECTED)) {
             statsScheduler.scheduleStatsGathering(room, statsListener(), STATS_DELAY);
         }

--- a/app/src/main/java/com/twilio/video/app/ui/settings/AdvancedSettingsFragment.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/settings/AdvancedSettingsFragment.kt
@@ -44,7 +44,7 @@ class AdvancedSettingsFragment : BaseSettingsFragment() {
                 findPreference(Preferences.AUDIO_CODEC) as ListPreference?)
 
         // Fill out the rest of settings
-        identityPreference = (findPreference(Preferences.DISPLAY_NAME) as EditTextPreference?)?.apply {
+        identityPreference = findPreference<EditTextPreference>(Preferences.DISPLAY_NAME)?.apply {
             summary = sharedPreferences.getString(Preferences.DISPLAY_NAME, null)
             setOnPreferenceChangeListener { _, newValue ->
                 summary = newValue as CharSequence?

--- a/app/src/main/java/com/twilio/video/app/ui/settings/InternalSettingsFragment.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/settings/InternalSettingsFragment.kt
@@ -10,12 +10,12 @@ class InternalSettingsFragment : BaseSettingsFragment() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.internal_preferences)
 
-        (findPreference(Preferences.ENVIRONMENT) as ListPreference?)?.run {
+        findPreference<ListPreference>(Preferences.ENVIRONMENT)?.run {
             value = sharedPreferences.getString(Preferences.ENVIRONMENT,
                     Preferences.ENVIRONMENT_DEFAULT)
         }
 
-        (findPreference(Preferences.TOPOLOGY) as ListPreference?)?.run {
+        findPreference<ListPreference>(Preferences.TOPOLOGY)?.run {
             value = sharedPreferences.getString(Preferences.TOPOLOGY,
                     Preferences.TOPOLOGY_DEFAULT)
         }

--- a/app/src/main/res/layout/stats_layout.xml
+++ b/app/src/main/res/layout/stats_layout.xml
@@ -68,7 +68,9 @@
                 android:text="@string/stats_bytes_sent"
                 android:gravity="start"
                 android:paddingLeft="0dp"
+                android:paddingStart="0dp"
                 android:paddingRight="5dp"
+                android:paddingEnd="5dp"
                 style="@style/Stats.TextTitle" />
                 <TextView
                 android:id="@+id/stats_bytes_value"
@@ -82,7 +84,9 @@
                 android:gravity="start"
                 android:text="@string/stats_rtt"
                 android:paddingLeft="0dp"
+                android:paddingStart="0dp"
                 android:paddingRight="5dp"
+                android:paddingEnd="5dp"
                 style="@style/Stats.TextTitle"/>
             <TextView
                 android:id="@+id/stats_rtt_value"

--- a/app/src/main/res/layout/stats_layout.xml
+++ b/app/src/main/res/layout/stats_layout.xml
@@ -67,8 +67,10 @@
                 android:id="@+id/stats_bytes_title"
                 android:text="@string/stats_bytes_sent"
                 android:gravity="start"
-                style="@style/Stats.TextTitle"/>
-            <TextView
+                android:paddingLeft="0dp"
+                android:paddingRight="5dp"
+                style="@style/Stats.TextTitle" />
+                <TextView
                 android:id="@+id/stats_bytes_value"
                 android:gravity="start"
                 style="@style/Stats.TextValue"/>
@@ -79,6 +81,8 @@
                 android:id="@+id/stats_rtt_title"
                 android:gravity="start"
                 android:text="@string/stats_rtt"
+                android:paddingLeft="0dp"
+                android:paddingRight="5dp"
                 style="@style/Stats.TextTitle"/>
             <TextView
                 android:id="@+id/stats_rtt_value"


### PR DESCRIPTION
## Description

Enable stats by default and fix a bug in the stats UI.

## Validation

- Connected to room and validated stats UI

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
