### PR TITLE
Add audio device change icons

### DIFF
--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-    xmlns:tools="http://schemas.android.com/tools"
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.twilio.video.app.e2eTest">
+
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
 
     <uses-sdk tools:overrideLibrary="android_libs.ub_uiautomator" />
 </manifest>

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.twilio.video.app.e2eTest">
-
-    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
 
     <uses-sdk tools:overrideLibrary="android_libs.ub_uiautomator" />
 </manifest>

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/LoginTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/LoginTest.kt
@@ -14,7 +14,7 @@ import com.twilio.video.app.ui.splash.SplashActivity
 import com.twilio.video.app.util.getString
 import com.twilio.video.app.util.retrieveEmailCredentials
 import com.twilio.video.app.util.retryEspressoAction
-import com.twilio.video.app.util.scrollAndClick
+import com.twilio.video.app.util.scrollAndClickView
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,7 +37,7 @@ class LoginTest {
         val emailCredentials = retrieveEmailCredentials()
         loginWithEmail(emailCredentials)
         retryEspressoAction { clickSettingsMenuItem() }
-        scrollAndClick(getString(R.string.settings_screen_logout), R.id.recycler_view)
+        scrollAndClickView(getString(R.string.settings_screen_logout), R.id.recycler_view)
 
         retryEspressoAction { assertGoogleSignInButtonIsVisible() }
     }

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/PreferencesTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/PreferencesTest.kt
@@ -10,7 +10,7 @@ import com.twilio.video.app.ui.splash.SplashActivity
 import com.twilio.video.app.util.assertTextIsDisplayedRetry
 import com.twilio.video.app.util.getString
 import com.twilio.video.app.util.retryEspressoAction
-import com.twilio.video.app.util.scrollAndClick
+import com.twilio.video.app.util.scrollAndClickView
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -29,11 +29,11 @@ class PreferencesTest : BaseE2ETest() {
 
         assertTextIsDisplayedRetry(getString(R.string.settings_title))
 
-        scrollAndClick(getString(R.string.settings_title_advanced), R.id.recycler_view)
+        scrollAndClickView(getString(R.string.settings_title_advanced), R.id.recycler_view)
 
         assertTextIsDisplayedRetry(getString(R.string.settings_title_advanced))
 
-        scrollAndClick(getString(R.string.settings_title_bandwidth_profile), R.id.recycler_view)
+        scrollAndClickView(getString(R.string.settings_title_bandwidth_profile), R.id.recycler_view)
 
         assertTextIsDisplayedRetry(getString(R.string.settings_title_bandwidth_profile))
 

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/RoomTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/RoomTest.kt
@@ -1,8 +1,14 @@
 package com.twilio.video.app.e2eTest
 
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import com.twilio.video.app.R
+import com.twilio.video.app.espresso.DrawableMatcher
 import com.twilio.video.app.screen.assertRoomIsConnected
 import com.twilio.video.app.screen.clickDisconnectButton
 import com.twilio.video.app.screen.clickJoinRoomButton
@@ -10,6 +16,9 @@ import com.twilio.video.app.screen.clickMicButton
 import com.twilio.video.app.screen.clickVideoButton
 import com.twilio.video.app.screen.enterRoomName
 import com.twilio.video.app.ui.splash.SplashActivity
+import com.twilio.video.app.util.assertTextIsDisplayedRetry
+import com.twilio.video.app.util.clickView
+import com.twilio.video.app.util.getTargetContext
 import com.twilio.video.app.util.randomUUID
 import com.twilio.video.app.util.retryEspressoAction
 import org.junit.Rule
@@ -44,5 +53,51 @@ class RoomTest : BaseE2ETest() {
         retryEspressoAction { assertRoomIsConnected() }
 
         clickDisconnectButton()
+    }
+
+    @Test
+    fun it_should_display_the_earpiece_icon_by_default() {
+        val earpieceDrawableMatcher = DrawableMatcher(getTargetContext(),
+                R.drawable.ic_phonelink_ring_white_24dp)
+        drawableIsDisplayed(earpieceDrawableMatcher)
+
+        enterRoomName(randomUUID())
+        clickJoinRoomButton()
+
+        retryEspressoAction { assertRoomIsConnected() }
+        drawableIsDisplayed(earpieceDrawableMatcher)
+
+        clickDisconnectButton()
+    }
+
+    @Test
+    fun it_should_display_the_speakerphone_icon_when_selected() {
+        val earpieceDrawableMatcher = DrawableMatcher(getTargetContext(),
+                R.drawable.ic_phonelink_ring_white_24dp)
+        val speakerphoneDrawableMatcher = DrawableMatcher(getTargetContext(),
+                R.drawable.ic_volume_up_white_24dp)
+        drawableIsDisplayed(earpieceDrawableMatcher)
+
+        onView(withId(R.id.device_menu_item)).perform(click())
+
+        val speakerphoneName = "Speakerphone"
+        assertTextIsDisplayedRetry(speakerphoneName)
+
+        clickView(speakerphoneName)
+        retryEspressoAction { drawableIsDisplayed(speakerphoneDrawableMatcher) }
+
+        enterRoomName(randomUUID())
+        clickJoinRoomButton()
+
+        retryEspressoAction { assertRoomIsConnected() }
+        drawableIsDisplayed(speakerphoneDrawableMatcher)
+
+        clickDisconnectButton()
+    }
+
+    private fun drawableIsDisplayed(earpieceDrawableMatcher: DrawableMatcher) {
+        retryEspressoAction(timeoutInMillis = 2000L) {
+            onView(withId(R.id.device_menu_item)).check(matches(earpieceDrawableMatcher))
+        }
     }
 }

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/RoomTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/RoomTest.kt
@@ -96,7 +96,7 @@ class RoomTest : BaseE2ETest() {
     }
 
     private fun drawableIsDisplayed(earpieceDrawableMatcher: DrawableMatcher) {
-        retryEspressoAction(timeoutInMillis = 2000L) {
+        retryEspressoAction {
             onView(withId(R.id.device_menu_item)).check(matches(earpieceDrawableMatcher))
         }
     }

--- a/app/src/androidTest/java/com/twilio/video/app/espresso/DrawableMatchers.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/espresso/DrawableMatchers.kt
@@ -1,0 +1,35 @@
+package com.twilio.video.app.espresso
+
+import android.content.Context
+import android.content.res.Resources
+import android.graphics.drawable.Drawable
+import android.view.View
+import android.widget.ImageView
+import androidx.annotation.DrawableRes
+import androidx.appcompat.view.menu.ActionMenuItemView
+import org.hamcrest.Description
+import org.hamcrest.TypeSafeMatcher
+
+class DrawableMatcher(
+    private val targetContext: Context,
+    @param:DrawableRes private val expectedId: Int
+) : TypeSafeMatcher<View>(View::class.java) {
+
+    override fun matchesSafely(target: View): Boolean {
+        val drawable: Drawable? = when (target) {
+            is ActionMenuItemView -> target.itemData.icon
+            is ImageView -> target.drawable
+            else -> null
+        }
+        requireNotNull(drawable)
+
+        val resources: Resources = target.context.resources
+        val expectedDrawable: Drawable? = resources.getDrawable(expectedId, targetContext.theme)
+        return expectedDrawable?.constantState?.let { it == drawable.constantState } ?: false
+    }
+
+    override fun describeTo(description: Description) {
+        description.appendText("with drawable from resource id: $expectedId")
+        targetContext.resources.getResourceEntryName(expectedId)?.let { description.appendText("[$it]") }
+    }
+}

--- a/app/src/androidTest/java/com/twilio/video/app/espresso/HiddenView.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/espresso/HiddenView.kt
@@ -1,4 +1,4 @@
-package com.twilio.video.app
+package com.twilio.video.app.espresso
 
 import android.view.View
 import androidx.test.espresso.NoMatchingViewException

--- a/app/src/androidTest/java/com/twilio/video/app/screen/LobbyScreen.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/screen/LobbyScreen.kt
@@ -10,8 +10,8 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import com.twilio.video.app.HiddenView
 import com.twilio.video.app.R
+import com.twilio.video.app.espresso.HiddenView
 import com.twilio.video.app.util.getString
 import com.twilio.video.app.util.getTargetContext
 import org.hamcrest.CoreMatchers.not

--- a/app/src/androidTest/java/com/twilio/video/app/util/EspressoUtil.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/util/EspressoUtil.kt
@@ -11,7 +11,11 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.not
 
-fun scrollAndClick(viewText: String, recyclerViewId: Int) {
+fun clickView(viewText: String) {
+    onView(withText(viewText)).perform(click())
+}
+
+fun scrollAndClickView(viewText: String, recyclerViewId: Int) {
     onView(withId(recyclerViewId))
             .perform(actionOnItem<RecyclerView.ViewHolder>(hasDescendant(withText(viewText)), click()))
 }

--- a/app/src/androidTest/java/com/twilio/video/app/util/TestUtil.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/util/TestUtil.kt
@@ -11,11 +11,11 @@ import java.io.InputStreamReader
 import java.util.UUID
 import junit.framework.AssertionFailedError
 
-fun retryEspressoAction(timeoutInSeconds: Long = 60000L, espressoAction: () -> Unit) {
+fun retryEspressoAction(timeoutInMillis: Long = 10000L, espressoAction: () -> Unit) {
     val startTime = System.currentTimeMillis()
     var currentTime = 0L
     var exception: Throwable? = null
-    while (currentTime <= timeoutInSeconds) {
+    while (currentTime <= timeoutInMillis) {
         currentTime = try {
             espressoAction()
             return

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
@@ -50,6 +50,10 @@ import butterknife.ButterKnife
 import butterknife.OnClick
 import butterknife.OnTextChanged
 import com.google.android.material.snackbar.Snackbar
+import com.twilio.audioswitch.AudioDevice
+import com.twilio.audioswitch.AudioDevice.BluetoothHeadset
+import com.twilio.audioswitch.AudioDevice.Speakerphone
+import com.twilio.audioswitch.AudioDevice.WiredHeadset
 import com.twilio.audioswitch.AudioSwitch
 import com.twilio.video.AspectRatio
 import com.twilio.video.CameraCapturer
@@ -917,6 +921,7 @@ class RoomActivity : BaseActivity() {
         renderPrimaryView(roomViewState.primaryParticipant)
         renderThumbnails(roomViewState)
         updateLayout(roomViewState)
+        updateAudioDeviceIcon(roomViewState.selectedDevice)
     }
 
     private fun bindRoomViewEffects(roomViewEffectWrapper: ViewEffect<RoomViewEffect>) {
@@ -949,6 +954,16 @@ class RoomActivity : BaseActivity() {
                 handleTokenError(error)
             }
         }
+    }
+
+    private fun updateAudioDeviceIcon(selectedAudioDevice: AudioDevice?) {
+        val audioDeviceMenuIcon = when (selectedAudioDevice) {
+            is BluetoothHeadset -> R.drawable.ic_bluetooth_white_24dp
+            is WiredHeadset -> R.drawable.ic_headset_mic_white_24dp
+            is Speakerphone -> R.drawable.ic_volume_up_white_24dp
+            else -> R.drawable.ic_phonelink_ring_white_24dp
+        }
+        this.deviceMenuItem.setIcon(audioDeviceMenuIcon)
     }
 
     private fun renderPrimaryView(primaryParticipant: ParticipantViewState?) {

--- a/app/src/main/res/drawable/ic_bluetooth_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_bluetooth_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_devices_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_devices_white_24dp.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="#FFFFFF"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M4,6h18L22,4L4,4c-1.1,0 -2,0.9 -2,2v11L0,17v3h14v-3L4,17L4,6zM23,8h-6c-0.55,0 -1,0.45 -1,1v10c0,0.55 0.45,1 1,1h6c0.55,0 1,-0.45 1,-1L24,9c0,-0.55 -0.45,-1 -1,-1zM22,17h-4v-7h4v7z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_headset_mic_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_headset_mic_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12,1c-4.97,0 -9,4.03 -9,9v7c0,1.66 1.34,3 3,3h3v-8H5v-2c0,-3.87 3.13,-7 7,-7s7,3.13 7,7v2h-4v8h4v1h-7v2h6c1.66,0 3,-1.34 3,-3V10c0,-4.97 -4.03,-9 -9,-9z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_phonelink_ring_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_phonelink_ring_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M20.1,7.7l-1,1c1.8,1.8 1.8,4.6 0,6.5l1,1c2.5,-2.3 2.5,-6.1 0,-8.5zM18,9.8l-1,1c0.5,0.7 0.5,1.6 0,2.3l1,1c1.2,-1.2 1.2,-3 0,-4.3zM14,1L4,1c-1.1,0 -2,0.9 -2,2v18c0,1.1 0.9,2 2,2h10c1.1,0 2,-0.9 2,-2L16,3c0,-1.1 -0.9,-2 -2,-2zM14,20L4,20L4,4h10v16z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_volume_up_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_volume_up_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3,9v6h4l5,5L12,4L7,9L3,9zM16.5,12c0,-1.77 -1.02,-3.29 -2.5,-4.03v8.05c1.48,-0.73 2.5,-2.25 2.5,-4.02zM14,3.23v2.06c2.89,0.86 5,3.54 5,6.71s-2.11,5.85 -5,6.71v2.06c4.01,-0.91 7,-4.49 7,-8.77s-2.99,-7.86 -7,-8.77z"/>
+</vector>

--- a/app/src/main/res/menu/room_menu.xml
+++ b/app/src/main/res/menu/room_menu.xml
@@ -3,6 +3,11 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <item android:id="@+id/device_menu_item"
+        android:title="@string/select_audio_device"
+        android:icon="@drawable/ic_phonelink_ring_white_24dp"
+        app:showAsAction="ifRoom"/>
+
     <item android:id="@+id/switch_camera_menu_item"
           android:title="@string/switch_camera"
           android:icon="@drawable/ic_switch_camera_white_24dp"
@@ -13,11 +18,6 @@
           android:icon="@drawable/ic_screen_share_white_24dp"
           android:visible="false"
           app:showAsAction="ifRoom"/>
-
-    <item android:id="@+id/device_menu_item"
-        android:title="@string/select_audio_device"
-        android:icon="@drawable/ic_devices_white_24dp"
-        app:showAsAction="ifRoom"/>
 
     <item android:id="@+id/pause_audio_menu_item"
           android:title="@string/pause_audio"


### PR DESCRIPTION
## Description

The audio device menu item now matches the state of the selected audio device from AudioSwitch.

## Validation

- Passed CI.

## Addition Notes

Added `DrawableMatcher` to allow asserting a matching drawable in UI tests.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
