### PR TITLE
Update to Video Android 5.11.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'kotlin-kapt'
 def videoAndroidSdkDepProp = "videoAppSdkDependency"
 def videoAndroidSdkDep = (project.hasProperty(videoAndroidSdkDepProp) ?
         project("${project.property(videoAndroidSdkDepProp)}") :
-        "com.twilio:video-android:5.10.2")
+        "com.twilio:video-android:5.11.0")
 def versionCodeProperty = project.property('versionCode') as Integer
 
 android {


### PR DESCRIPTION
Update to [Video Android 5.11.0](https://www.twilio.com/docs/video/changelog-twilio-video-android#5110-september-16th-2020)