### PR TITLE
Upgrade AudioSwitch to 1.0.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,7 +167,7 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"
     implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0'
-    implementation 'com.twilio:audioswitch:1.0.0'
+    implementation 'com.twilio:audioswitch:1.0.1'
     implementation "io.uniflow:uniflow-androidx:$uniflowVersion"
 
     internalImplementation "com.microsoft.appcenter:appcenter-distribute:2.5.1"


### PR DESCRIPTION
## AudioSwitch 1.0.1

Enhancements

- Upgraded Kotlin to `1.4.0`.
- Improved the Bluetooth headset connection and audio change reliability by registering the `BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED` and `BluetoothHeadset.ACTION_AUDIO_STATE_CHANGED` intent actions instead of relying on `android.bluetooth.BluetoothDevice` and `android.media.AudioManager` intent actions.
- The context provided when constructing `AudioSwitch` can now take any context. Previously the `ApplicationContext` was required.

Bug Fixes

- Added the internal access modifier to the `SystemClockWrapper` class since it is not meant to be exposed publicly.

## Validation

- Passed CI.
- Manually validated on a Huawei P30 Lite.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
