### PR TITLE
AHOYAPPS-837: Support screen share when targeting Android 10+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,8 @@ def videoAndroidSdkDep = (project.hasProperty(videoAndroidSdkDepProp) ?
 def versionCodeProperty = project.property('versionCode') as Integer
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 30
+    buildToolsVersion '30.0.2'
 
     lintOptions {
         disable 'GradleDependency'
@@ -40,7 +40,7 @@ android {
         applicationId "com.twilio.video.app"
 
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 30
 
         versionName "0.1.0"
         versionCode versionCodeProperty

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,14 +125,14 @@ dependencies {
     def daggerAndroidProcessor = "com.google.dagger:dagger-android-processor:$daggerVersion"
     def daggerCompiler = "com.google.dagger:dagger-compiler:$daggerVersion"
     def retrofitVersion = '2.6.4'
-    def espressoVersion = '3.2.0'
+    def espressoVersion = '3.3.0'
     def espresso = "androidx.test.espresso:espresso-core:$espressoVersion"
-    def androidXTest = '1.2.0'
+    def androidXTest = '1.3.0'
     def testCore = "androidx.test:core:$androidXTest"
     def junitExtensions = 'androidx.test.ext:junit-ktx:1.1.1'
     def lifecycleVersion = '2.2.0'
     def coroutinesAndroidVersion = '1.3.9'
-    def fragmentVersion = '1.2.2'
+    def fragmentVersion = '1.2.5'
     def uniflowVersion = '0.11.2'
 
     implementation 'com.facebook.conceal:conceal:2.0.2@aar'
@@ -142,8 +142,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$coroutinesAndroidVersion"
     implementation 'com.twilio:twilio-android-env:1.0.0'
     implementation videoAndroidSdkDep
-    implementation "androidx.constraintlayout:constraintlayout:1.1.3"
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation "androidx.constraintlayout:constraintlayout:2.0.1"
+    implementation 'com.google.android.material:material:1.2.1'
     implementation "androidx.preference:preference-ktx:1.1.1"
     implementation "androidx.lifecycle:lifecycle-service:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata:$lifecycleVersion"
@@ -154,10 +154,10 @@ dependencies {
     implementation "com.appyvet:materialrangebar:1.3"
     implementation "com.jakewharton:butterknife:$butterknifeVersion"
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation "com.google.firebase:firebase-core:17.2.2"
-    implementation 'com.google.firebase:firebase-auth:19.2.0'
+    implementation "com.google.firebase:firebase-core:17.5.0"
+    implementation 'com.google.firebase:firebase-auth:19.4.0'
     implementation "com.crashlytics.sdk.android:crashlytics:2.10.1"
-    implementation 'com.google.android.gms:play-services-auth:17.0.0'
+    implementation 'com.google.android.gms:play-services-auth:18.1.0'
     implementation "com.google.dagger:dagger-android:$daggerVersion"
     implementation "com.google.dagger:dagger:$daggerVersion"
     implementation "com.google.dagger:dagger-android-support:$daggerVersion"
@@ -180,7 +180,7 @@ dependencies {
     testImplementation espresso
     testImplementation junitExtensions
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesAndroidVersion"
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
@@ -196,7 +196,7 @@ dependencies {
     androidTestImplementation "androidx.test:runner:$androidXTest"
     androidTestImplementation "androidx.test:rules:$androidXTest"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$espressoVersion"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'com.squareup.rx.idler:rx2-idler:0.9.1'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,6 +54,8 @@
         <activity android:name=".ui.settings.SettingsActivity"
             android:parentActivityName=".ui.room.RoomActivity"
             android:theme="@style/AppTheme.Settings" />
-        <service android:name=".ui.room.VideoService"/>
+        <service
+            android:foregroundServiceType="mediaProjection"
+            android:name=".ui.room.VideoService"/>
     </application>
 </manifest>

--- a/app/src/main/res/layout-v21/activity_room.xml
+++ b/app/src/main/res/layout-v21/activity_room.xml
@@ -77,7 +77,6 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginEnd="@dimen/fab_margin"
-            android:layout_marginRight="@dimen/fab_margin"
             android:orientation="vertical"
             android:gravity="end|bottom">
 
@@ -136,7 +135,6 @@
                 style="@style/AppTheme.Lobby.Drawer"
                 android:textSize="20sp"
                 android:layout_marginTop="@dimen/activity_horizontal_margin"
-                android:layout_marginRight="@dimen/activity_horizontal_margin"
                 android:layout_gravity="end"
                 android:layout_marginEnd="@dimen/activity_horizontal_margin"/>
 


### PR DESCRIPTION
## Description

The app now targets Android API 30 with support for screen share.

## Validation

- Passed CI.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
