### PR TITLE
Implement Go Room Type Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This application demonstrates multi-party voice and video built with [Twilio’s Programmable Video Android SDK](https://www.twilio.com/docs/video).
 
-![video-app-screenshots](https://user-images.githubusercontent.com/1930363/76543029-867ec080-644b-11ea-8145-d15d3fe9f7ea.png)
+![App Preview](https://user-images.githubusercontent.com/12685223/94631109-cfca1c80-0284-11eb-8b72-c97276cf34e4.png)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ If any errors occur after running a [Twilio CLI RTC Plugin](https://github.com/t
 1. Run `twilio rtc:apps:video:delete` to delete any existing authentication servers.
 1. Run `twilio rtc:apps:video:deploy --authentication passcode` to deploy a new authentication server.
 
-## App Behavior with Different Room Types
+#### App Behavior with Different Room Types
+
+**NOTE:** Usage charges will apply for most room types. See [pricing](https://www.twilio.com/video/pricing) for more information.
 
 After running the command [to deploy a Twilio Access Token Server](https://github.com/twilio/twilio-video-app-android#deploy-twilio-access-token-server), the room type will be returned in the command line output. Each room type provides a different video experience. More details about these room types can be found [here](https://www.twilio.com/docs/video/tutorials/understanding-video-rooms). The rest of this section explains how these room types affect the behavior of the video app.
 
@@ -58,6 +60,8 @@ After running the command [to deploy a Twilio Access Token Server](https://githu
 *Small Group* - The Small Group room type provides an identical group video app experience except for a smaller limit of four participants.
 
 *Peer-to-peer* - Although up to ten participants can join a room using the Peer-to-peer (P2P) room type, it is ideal for a one to one video experience. The NQL indicators, bandwidth profiles, and dominant speaker cannot be used with this room type. Thus, they are not demonstrated in the video app. Also, the VP8 video codec with simulcast disabled and 720p minimum video capturing dimensions are also set by default in order to provide an optimal one to one video app experience. If more than ten participants join a room with this room type, then the video app will present an error.
+
+*Go* - The Go room type provides a similar Peer-to-peer video app experience except for a smaller limit of two participants. If more than two participants join a room with this room type, then the video app will present an error.
 
 If the max number of participants is exceeded, then the video app will present an error for all room types.
 

--- a/app/src/community/java/com/twilio/video/app/data/api/AuthServiceRepository.kt
+++ b/app/src/community/java/com/twilio/video/app/data/api/AuthServiceRepository.kt
@@ -27,6 +27,7 @@ import com.twilio.video.app.data.Preferences.TOPOLOGY
 import com.twilio.video.app.data.Preferences.VIDEO_CODEC
 import com.twilio.video.app.data.Preferences.VIDEO_DIMENSIONS
 import com.twilio.video.app.data.Preferences.VP8_SIMULCAST
+import com.twilio.video.app.data.api.model.Topology.GO
 import com.twilio.video.app.data.api.model.Topology.GROUP
 import com.twilio.video.app.data.api.model.Topology.GROUP_SMALL
 import com.twilio.video.app.data.api.model.Topology.PEER_TO_PEER
@@ -93,7 +94,7 @@ class AuthServiceRepository(
                     sharedPreferences.edit { putString(TOPOLOGY, serverTopology.value) }
                     val (enableSimulcast, minVideoDimensions) = when (serverTopology) {
                         GROUP, GROUP_SMALL -> true to 0
-                        PEER_TO_PEER -> false to VIDEO_DIMENSIONS.indexOf(HD_720P_VIDEO_DIMENSIONS)
+                        PEER_TO_PEER, GO -> false to VIDEO_DIMENSIONS.indexOf(HD_720P_VIDEO_DIMENSIONS)
                     }
                     Timber.d("Server topology has changed to %s. Setting the codec to Vp8 with simulcast set to %s",
                             serverTopology, enableSimulcast)

--- a/app/src/main/java/com/twilio/video/app/data/api/model/Topology.kt
+++ b/app/src/main/java/com/twilio/video/app/data/api/model/Topology.kt
@@ -20,11 +20,13 @@ import com.google.gson.annotations.SerializedName
 private const val GROUP_ROOM_NAME = "group"
 private const val GROUP_SMALL_ROOM_NAME = "group-small"
 private const val PEER_TO_PEER_ROOM_NAME = "peer-to-peer"
+private const val GO_ROOM_NAME = "go"
 
 enum class Topology(val value: String) {
     @SerializedName(GROUP_ROOM_NAME) GROUP(GROUP_ROOM_NAME),
     @SerializedName(GROUP_SMALL_ROOM_NAME) GROUP_SMALL(GROUP_SMALL_ROOM_NAME),
-    @SerializedName(PEER_TO_PEER_ROOM_NAME) PEER_TO_PEER(PEER_TO_PEER_ROOM_NAME);
+    @SerializedName(PEER_TO_PEER_ROOM_NAME) PEER_TO_PEER(PEER_TO_PEER_ROOM_NAME),
+    @SerializedName(GO_ROOM_NAME) GO(GO_ROOM_NAME);
 
     override fun toString() = value
 }

--- a/app/src/main/java/com/twilio/video/app/sdk/LocalParticipantListener.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/LocalParticipantListener.kt
@@ -20,7 +20,7 @@ class LocalParticipantListener(private val roomManager: RoomManager) : LocalPart
         Timber.i("LocalParticipant NetworkQualityLevel changed for LocalParticipant sid: %s, NetworkQualityLevel: %s",
                 localParticipant.sid, networkQualityLevel)
 
-        roomManager.sendParticipantEvent(NetworkQualityLevelChange(localParticipant.sid, networkQualityLevel))
+        roomManager.sendRoomEvent(NetworkQualityLevelChange(localParticipant.sid, networkQualityLevel))
     }
 
     override fun onVideoTrackPublished(localParticipant: LocalParticipant, localVideoTrackPublication: LocalVideoTrackPublication) {
@@ -28,10 +28,10 @@ class LocalParticipantListener(private val roomManager: RoomManager) : LocalPart
                 localParticipant.sid, localVideoTrackPublication.localVideoTrack)
 
         if (localVideoTrackPublication.videoTrack.name.contains(SCREEN_TRACK_NAME)) {
-            roomManager.sendParticipantEvent(ScreenTrackUpdated(localParticipant.sid,
+            roomManager.sendRoomEvent(ScreenTrackUpdated(localParticipant.sid,
                     localVideoTrackPublication.videoTrack))
         } else {
-            roomManager.sendParticipantEvent(VideoTrackUpdated(localParticipant.sid,
+            roomManager.sendRoomEvent(VideoTrackUpdated(localParticipant.sid,
                     localVideoTrackPublication.videoTrack))
         }
     }

--- a/app/src/main/java/com/twilio/video/app/sdk/RemoteParticipantListener.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/RemoteParticipantListener.kt
@@ -22,7 +22,7 @@ class RemoteParticipantListener(private val roomManager: RoomManager) : RemotePa
         Timber.i("RemoteVideoTrack switched off for RemoteParticipant sid: %s, RemoteVideoTrack sid: %s",
                 remoteParticipant.sid, remoteVideoTrack.sid)
 
-        roomManager.sendParticipantEvent(TrackSwitchOff(remoteParticipant.sid, remoteVideoTrack,
+        roomManager.sendRoomEvent(TrackSwitchOff(remoteParticipant.sid, remoteVideoTrack,
                 true))
     }
 
@@ -30,7 +30,7 @@ class RemoteParticipantListener(private val roomManager: RoomManager) : RemotePa
         Timber.i("RemoteVideoTrack switched on for RemoteParticipant sid: %s, RemoteVideoTrack sid: %s",
                 remoteParticipant.sid, remoteVideoTrack.sid)
 
-        roomManager.sendParticipantEvent(TrackSwitchOff(remoteParticipant.sid, remoteVideoTrack,
+        roomManager.sendRoomEvent(TrackSwitchOff(remoteParticipant.sid, remoteVideoTrack,
                 false))
     }
 
@@ -39,9 +39,9 @@ class RemoteParticipantListener(private val roomManager: RoomManager) : RemotePa
                 remoteParticipant.sid, remoteVideoTrack.sid)
 
         if (remoteVideoTrack.name.contains(SCREEN_TRACK_NAME))
-            roomManager.sendParticipantEvent(ScreenTrackUpdated(remoteParticipant.sid, remoteVideoTrack))
+            roomManager.sendRoomEvent(ScreenTrackUpdated(remoteParticipant.sid, remoteVideoTrack))
         else
-            roomManager.sendParticipantEvent(VideoTrackUpdated(remoteParticipant.sid, remoteVideoTrack))
+            roomManager.sendRoomEvent(VideoTrackUpdated(remoteParticipant.sid, remoteVideoTrack))
     }
 
     override fun onVideoTrackUnsubscribed(remoteParticipant: RemoteParticipant, remoteVideoTrackPublication: RemoteVideoTrackPublication, remoteVideoTrack: RemoteVideoTrack) {
@@ -49,16 +49,16 @@ class RemoteParticipantListener(private val roomManager: RoomManager) : RemotePa
                 remoteParticipant.sid, remoteVideoTrack.sid)
 
         if (remoteVideoTrack.name.contains(SCREEN_TRACK_NAME))
-            roomManager.sendParticipantEvent(ScreenTrackUpdated(remoteParticipant.sid, null))
+            roomManager.sendRoomEvent(ScreenTrackUpdated(remoteParticipant.sid, null))
         else
-            roomManager.sendParticipantEvent(VideoTrackUpdated(remoteParticipant.sid, null))
+            roomManager.sendRoomEvent(VideoTrackUpdated(remoteParticipant.sid, null))
     }
 
     override fun onNetworkQualityLevelChanged(remoteParticipant: RemoteParticipant, networkQualityLevel: NetworkQualityLevel) {
         Timber.i("RemoteParticipant NetworkQualityLevel changed for RemoteParticipant sid: %s, NetworkQualityLevel: %s",
                 remoteParticipant.sid, networkQualityLevel)
 
-        roomManager.sendParticipantEvent(NetworkQualityLevelChange(remoteParticipant.sid,
+        roomManager.sendRoomEvent(NetworkQualityLevelChange(remoteParticipant.sid,
                 networkQualityLevel))
     }
 
@@ -66,42 +66,42 @@ class RemoteParticipantListener(private val roomManager: RoomManager) : RemotePa
         Timber.i("RemoteParticipant AudioTrack subscribed for RemoteParticipant sid: %s, RemoteAudioTrack sid: %s",
                 remoteParticipant.sid, remoteAudioTrack.sid)
 
-        roomManager.sendParticipantEvent(MuteParticipant(remoteParticipant.sid, false))
+        roomManager.sendRoomEvent(MuteParticipant(remoteParticipant.sid, false))
     }
 
     override fun onAudioTrackUnsubscribed(remoteParticipant: RemoteParticipant, remoteAudioTrackPublication: RemoteAudioTrackPublication, remoteAudioTrack: RemoteAudioTrack) {
         Timber.i("RemoteParticipant AudioTrack unsubscribed for RemoteParticipant sid: %s, RemoteAudioTrack sid: %s",
                 remoteParticipant.sid, remoteAudioTrack.sid)
 
-        roomManager.sendParticipantEvent(MuteParticipant(remoteParticipant.sid, true))
+        roomManager.sendRoomEvent(MuteParticipant(remoteParticipant.sid, true))
     }
 
     override fun onAudioTrackPublished(remoteParticipant: RemoteParticipant, remoteAudioTrackPublication: RemoteAudioTrackPublication) {
         Timber.i("RemoteParticipant AudioTrack published for RemoteParticipant sid: %s, RemoteAudioTrack sid: %s",
                 remoteParticipant.sid, remoteParticipant.sid)
 
-        roomManager.sendParticipantEvent(MuteParticipant(remoteParticipant.sid, false))
+        roomManager.sendRoomEvent(MuteParticipant(remoteParticipant.sid, false))
     }
 
     override fun onAudioTrackUnpublished(remoteParticipant: RemoteParticipant, remoteAudioTrackPublication: RemoteAudioTrackPublication) {
         Timber.i("RemoteParticipant AudioTrack unpublished for RemoteParticipant sid: %s, RemoteAudioTrack sid: %s",
                 remoteParticipant.sid, remoteParticipant.sid)
 
-        roomManager.sendParticipantEvent(MuteParticipant(remoteParticipant.sid, true))
+        roomManager.sendRoomEvent(MuteParticipant(remoteParticipant.sid, true))
     }
 
     override fun onAudioTrackEnabled(remoteParticipant: RemoteParticipant, remoteAudioTrackPublication: RemoteAudioTrackPublication) {
         Timber.i("RemoteParticipant AudioTrack enabled for RemoteParticipant sid: %s, RemoteAudioTrack sid: %s",
                 remoteParticipant.sid, remoteParticipant.sid)
 
-        roomManager.sendParticipantEvent(MuteParticipant(remoteParticipant.sid, false))
+        roomManager.sendRoomEvent(MuteParticipant(remoteParticipant.sid, false))
     }
 
     override fun onAudioTrackDisabled(remoteParticipant: RemoteParticipant, remoteAudioTrackPublication: RemoteAudioTrackPublication) {
         Timber.i("RemoteParticipant AudioTrack disabled for RemoteParticipant sid: %s, RemoteAudioTrack sid: %s",
                 remoteParticipant.sid, remoteParticipant.sid)
 
-        roomManager.sendParticipantEvent(MuteParticipant(remoteParticipant.sid, true))
+        roomManager.sendRoomEvent(MuteParticipant(remoteParticipant.sid, true))
     }
 
     override fun onDataTrackPublished(remoteParticipant: RemoteParticipant, remoteDataTrackPublication: RemoteDataTrackPublication) {}

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomEvent.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomEvent.kt
@@ -16,6 +16,7 @@ sealed class RoomEvent {
     ) : RoomEvent()
     object Disconnected : RoomEvent()
     object ConnectFailure : RoomEvent()
+    object MaxParticipantFailure : RoomEvent()
     data class TokenError(val serviceError: AuthServiceError? = null) : RoomEvent()
     data class DominantSpeakerChanged(val newDominantSpeakerSid: String?) : RoomEvent()
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewEffect.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewEffect.kt
@@ -13,5 +13,6 @@ sealed class RoomViewEffect : UIEvent() {
     object Disconnected : RoomViewEffect()
 
     object ShowConnectFailureDialog : RoomViewEffect()
+    object ShowMaxParticipantFailureDialog : RoomViewEffect()
     data class ShowTokenErrorDialog(val serviceError: AuthServiceError? = null) : RoomViewEffect()
 }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -15,6 +15,7 @@ import com.twilio.video.app.ui.room.RoomEvent.Connected
 import com.twilio.video.app.ui.room.RoomEvent.Connecting
 import com.twilio.video.app.ui.room.RoomEvent.Disconnected
 import com.twilio.video.app.ui.room.RoomEvent.DominantSpeakerChanged
+import com.twilio.video.app.ui.room.RoomEvent.MaxParticipantFailure
 import com.twilio.video.app.ui.room.RoomEvent.ParticipantEvent
 import com.twilio.video.app.ui.room.RoomEvent.ParticipantEvent.MuteParticipant
 import com.twilio.video.app.ui.room.RoomEvent.ParticipantEvent.NetworkQualityLevelChange
@@ -26,6 +27,7 @@ import com.twilio.video.app.ui.room.RoomEvent.ParticipantEvent.VideoTrackUpdated
 import com.twilio.video.app.ui.room.RoomEvent.TokenError
 import com.twilio.video.app.ui.room.RoomViewEffect.CheckLocalMedia
 import com.twilio.video.app.ui.room.RoomViewEffect.ShowConnectFailureDialog
+import com.twilio.video.app.ui.room.RoomViewEffect.ShowMaxParticipantFailureDialog
 import com.twilio.video.app.ui.room.RoomViewEffect.ShowTokenErrorDialog
 import com.twilio.video.app.ui.room.RoomViewEvent.ActivateAudioDevice
 import com.twilio.video.app.ui.room.RoomViewEvent.CheckPermissions
@@ -160,6 +162,12 @@ class RoomViewModel(
                 sendEvent {
                     showLobbyViewState()
                     ShowConnectFailureDialog
+                }
+            }
+            is MaxParticipantFailure -> action {
+                sendEvent {
+                    showLobbyViewState()
+                    ShowMaxParticipantFailureDialog
                 }
             }
             is TokenError -> action {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <!--  Room Screen  -->
     <string name="room_screen_connection_failure_title">Connection Failure</string>
     <string name="room_screen_connection_failure_message">Failed to connect to the room.</string>
+    <string name="room_screen_max_participant_failure_message">Room contains too many participants.</string>
     <string name="room_screen_token_retrieval_failure_message">Failed to retrieve the room token.</string>
     <string name="room_screen_token_expired_message">Passcode expired. Please sign in with a new passcode.</string>
     <string name="room_screen_select_device">Select Device</string>

--- a/app/src/testCommunity/java/com/twilio/video/app/data/api/AuthServiceRepositoryTest.kt
+++ b/app/src/testCommunity/java/com/twilio/video/app/data/api/AuthServiceRepositoryTest.kt
@@ -17,6 +17,7 @@ import com.twilio.video.app.data.Preferences.VIDEO_CODEC
 import com.twilio.video.app.data.Preferences.VIDEO_DIMENSIONS
 import com.twilio.video.app.data.Preferences.VP8_SIMULCAST
 import com.twilio.video.app.data.api.model.Topology
+import com.twilio.video.app.data.api.model.Topology.GO
 import com.twilio.video.app.data.api.model.Topology.GROUP
 import com.twilio.video.app.data.api.model.Topology.GROUP_SMALL
 import com.twilio.video.app.data.api.model.Topology.PEER_TO_PEER
@@ -188,7 +189,8 @@ class AuthServiceRepositoryTest {
             arrayOf(
                     arrayOf(GROUP, GROUP_SMALL, true, 0),
                     arrayOf(PEER_TO_PEER, GROUP, true, 0),
-                    arrayOf(GROUP_SMALL, PEER_TO_PEER, false, VIDEO_DIMENSIONS.indexOf(HD_720P_VIDEO_DIMENSIONS))
+                    arrayOf(GROUP_SMALL, PEER_TO_PEER, false, VIDEO_DIMENSIONS.indexOf(HD_720P_VIDEO_DIMENSIONS)),
+                    arrayOf(GROUP, GO, false, VIDEO_DIMENSIONS.indexOf(HD_720P_VIDEO_DIMENSIONS))
             )
 
     @Parameters(method = "videoCodecParams")


### PR DESCRIPTION
## Description

This PR contains support for the Programmable Video Go room type. The Go room type provides a similar peer-to-peer video app experience except for a smaller limit of two participants. If more than two participants join a room with this room type, then the video app will present an error. To learn more about Go, please visit the [Twilio blog](https://www.twilio.com/blog/announcing-twilio-video-webrtc-go).

## Validation

- Manually validated each room type in the community flavor.
- Pass CI.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
