### PR TITLE
AHOYAPPS-889: Camera not rendered when launching app for the first time

### DIFF
--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/RoomTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/RoomTest.kt
@@ -1,9 +1,5 @@
 package com.twilio.video.app.e2eTest
 
-import android.content.Context
-import android.media.AudioDeviceInfo.TYPE_WIRED_HEADSET
-import android.media.AudioManager
-import android.media.AudioManager.GET_DEVICES_INPUTS
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -103,25 +99,9 @@ class RoomTest : BaseE2ETest() {
     }
 
     @Test
-    fun it_should_display_the_earpiece_icon_by_default() {
-        val defaultDrawableMatcher = getDefaultDrawableMatcher()
-        drawableIsDisplayed(defaultDrawableMatcher)
-
-        enterRoomName(randomUUID())
-        clickJoinRoomButton()
-
-        retryEspressoAction { assertRoomIsConnected() }
-        drawableIsDisplayed(defaultDrawableMatcher)
-
-        clickDisconnectButton()
-    }
-
-    @Test
     fun it_should_display_the_speakerphone_icon_when_selected() {
-        val defaultDrawableMatcher = getDefaultDrawableMatcher()
         val speakerphoneDrawableMatcher = DrawableMatcher(getTargetContext(),
                 R.drawable.ic_volume_up_white_24dp)
-        drawableIsDisplayed(defaultDrawableMatcher)
 
         onView(withId(R.id.device_menu_item)).perform(click())
 
@@ -138,19 +118,6 @@ class RoomTest : BaseE2ETest() {
         drawableIsDisplayed(speakerphoneDrawableMatcher)
 
         clickDisconnectButton()
-    }
-
-    private fun getDefaultDrawableMatcher(): DrawableMatcher {
-        /*
-         * Some FTL devices have headsets plugged in so we need to check for the default audio device
-         */
-        val audioManager = getTargetContext().getSystemService(Context.AUDIO_SERVICE) as AudioManager?
-        requireNotNull(audioManager)
-        val drawable = audioManager.getDevices(GET_DEVICES_INPUTS)
-                .find { it.type == TYPE_WIRED_HEADSET }
-                ?.let { R.drawable.ic_headset_mic_white_24dp }
-                ?: R.drawable.ic_phonelink_ring_white_24dp
-        return DrawableMatcher(getTargetContext(), drawable)
     }
 
     private fun drawableIsDisplayed(earpieceDrawableMatcher: DrawableMatcher) {

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/RoomTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/RoomTest.kt
@@ -7,12 +7,16 @@ import android.media.AudioManager.GET_DEVICES_INPUTS
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import com.twilio.video.app.R
 import com.twilio.video.app.espresso.DrawableMatcher
+import com.twilio.video.app.espresso.HiddenView
 import com.twilio.video.app.screen.assertRoomIsConnected
 import com.twilio.video.app.screen.clickDisconnectButton
 import com.twilio.video.app.screen.clickJoinRoomButton
@@ -22,9 +26,12 @@ import com.twilio.video.app.screen.enterRoomName
 import com.twilio.video.app.ui.splash.SplashActivity
 import com.twilio.video.app.util.assertTextIsDisplayedRetry
 import com.twilio.video.app.util.clickView
+import com.twilio.video.app.util.getString
 import com.twilio.video.app.util.getTargetContext
 import com.twilio.video.app.util.randomUUID
+import com.twilio.video.app.util.retrieveEmailCredentials
 import com.twilio.video.app.util.retryEspressoAction
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -45,6 +52,42 @@ class RoomTest : BaseE2ETest() {
         retryEspressoAction { assertRoomIsConnected() }
 
         clickDisconnectButton()
+    }
+
+    @Test
+    fun it_should_toggle_the_local_video_correctly_while_pinned() {
+        enterRoomName(randomUUID())
+        clickJoinRoomButton()
+
+        retryEspressoAction { assertRoomIsConnected() }
+
+        onView(allOf(withText(retrieveEmailCredentials().email), isDisplayed()))
+                .perform(click())
+        clickView(R.id.local_video_image_button)
+        onView(allOf(withId(R.id.participant_stub_image),
+                withContentDescription(getString(R.string.primary_profile_picture)))).check(matches(isDisplayed()))
+        onView(allOf(withId(R.id.participant_stub_image),
+                withContentDescription(getString(R.string.profile_picture)))).check(matches(isDisplayed()))
+        clickView(R.id.local_video_image_button)
+        onView(allOf(withId(R.id.participant_stub_image),
+                withContentDescription(getString(R.string.primary_profile_picture)))).check(HiddenView())
+        onView(allOf(withId(R.id.participant_stub_image),
+                withContentDescription(getString(R.string.profile_picture)))).check(HiddenView())
+
+        clickDisconnectButton()
+    }
+
+    @Test
+    fun it_should_toggle_the_local_video_correctly_in_lobby() {
+        clickView(R.id.local_video_image_button)
+
+        onView(withId(R.id.participant_stub_image)).check(matches(isDisplayed()))
+        onView(withId(R.id.participant_video)).check(HiddenView())
+
+        clickView(R.id.local_video_image_button)
+
+        onView(withId(R.id.participant_stub_image)).check(HiddenView())
+        onView(withId(R.id.participant_video)).check(matches(isDisplayed()))
     }
 
     @Test

--- a/app/src/androidTest/java/com/twilio/video/app/util/EspressoUtil.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/util/EspressoUtil.kt
@@ -1,5 +1,6 @@
 package com.twilio.video.app.util
 
+import androidx.annotation.IdRes
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -15,9 +16,17 @@ fun clickView(viewText: String) {
     onView(withText(viewText)).perform(click())
 }
 
+fun clickView(@IdRes id: Int) {
+    onView(withId(id)).perform(click())
+}
+
 fun scrollAndClickView(viewText: String, recyclerViewId: Int) {
     onView(withId(recyclerViewId))
             .perform(actionOnItem<RecyclerView.ViewHolder>(hasDescendant(withText(viewText)), click()))
+}
+
+fun assertTextIsDisplayed(text: String) {
+    onView(withText(text)).check(matches(isDisplayed()))
 }
 
 fun assertTextIsDisplayedRetry(text: String) {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
@@ -530,8 +530,11 @@ class RoomActivity : BaseActivity() {
         localVideoImageButton.setImageResource(
                 if (cameraVideoTrack != null) R.drawable.ic_videocam_white_24px else R.drawable.ic_videocam_off_gray_24px)
 
+        // Refresh view state
         localParticipant?.let { roomViewModel.processInput(ToggleLocalVideo(it.sid,
-                (newLocalVideoTrack as VideoTrack?)?.let { VideoTrackViewState(it) })) }
+                (newLocalVideoTrack as VideoTrack?)?.let { VideoTrackViewState(it) }))
+        }
+                ?: roomViewModel.processInput(RefreshViewState)
     }
 
     private fun publishVideoTrack(videoTrack: LocalVideoTrack, trackPriority: TrackPriority) {
@@ -647,14 +650,7 @@ class RoomActivity : BaseActivity() {
         }
     }
 
-    /**
-     * Render local video track.
-     *
-     *
-     * NOTE: Stub participant is created in controller. Make sure to remove it when connected to
-     * room.
-     */
-    private fun renderLocalParticipantStub() {
+    private fun renderLocalParticipant() {
         val cameraTrackViewState = cameraVideoTrack?.let { VideoTrackViewState(it, false) }
         cameraCapturer?.let { cameraCapturer ->
             primaryParticipantController.renderAsPrimary(
@@ -989,7 +985,7 @@ class RoomActivity : BaseActivity() {
                     primaryParticipant.isMuted,
                     primaryParticipant.isMirrored)
         } else {
-            renderLocalParticipantStub()
+            renderLocalParticipant()
         }
     }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
@@ -67,6 +67,7 @@ import com.twilio.video.StatsListener
 import com.twilio.video.StatsReport
 import com.twilio.video.TrackPriority
 import com.twilio.video.VideoConstraints
+import com.twilio.video.VideoTrack
 import com.twilio.video.app.R
 import com.twilio.video.app.adapter.StatsListAdapter
 import com.twilio.video.app.base.BaseActivity
@@ -486,6 +487,7 @@ class RoomActivity : BaseActivity() {
 
     @OnClick(R.id.local_video_image_button)
     fun toggleLocalVideo() {
+        var newLocalVideoTrack: LocalVideoTrack? = null
         if (cameraVideoTrack == null) {
             isVideoMuted = false
 
@@ -497,6 +499,7 @@ class RoomActivity : BaseActivity() {
                         it.videoCapturer,
                         videoConstraints,
                         CAMERA_TRACK_NAME)
+                newLocalVideoTrack = cameraVideoTrack
             }
             if (localParticipant != null) {
                 cameraVideoTrack?.let { publishVideoTrack(it, TrackPriority.LOW) }
@@ -509,7 +512,6 @@ class RoomActivity : BaseActivity() {
                 pauseVideoMenuItem.isVisible = true
             }
         } else {
-            localParticipant?.let { roomViewModel.processInput(ToggleLocalVideo(it.sid)) }
             isVideoMuted = true
             // remove local camera track
             cameraVideoTrack?.let { cameraVideoTrack ->
@@ -527,7 +529,9 @@ class RoomActivity : BaseActivity() {
         // update toggle button icon
         localVideoImageButton.setImageResource(
                 if (cameraVideoTrack != null) R.drawable.ic_videocam_white_24px else R.drawable.ic_videocam_off_gray_24px)
-        roomViewModel.processInput(RefreshViewState)
+
+        localParticipant?.let { roomViewModel.processInput(ToggleLocalVideo(it.sid,
+                (newLocalVideoTrack as VideoTrack?)?.let { VideoTrackViewState(it) })) }
     }
 
     private fun publishVideoTrack(videoTrack: LocalVideoTrack, trackPriority: TrackPriority) {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
@@ -486,7 +486,6 @@ class RoomActivity : BaseActivity() {
 
     @OnClick(R.id.local_video_image_button)
     fun toggleLocalVideo() {
-        localParticipant?.let { roomViewModel.processInput(ToggleLocalVideo(it.sid)) }
         if (cameraVideoTrack == null) {
             isVideoMuted = false
 
@@ -510,6 +509,7 @@ class RoomActivity : BaseActivity() {
                 pauseVideoMenuItem.isVisible = true
             }
         } else {
+            localParticipant?.let { roomViewModel.processInput(ToggleLocalVideo(it.sid)) }
             isVideoMuted = true
             // remove local camera track
             cameraVideoTrack?.let { cameraVideoTrack ->

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewEvent.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewEvent.kt
@@ -1,6 +1,7 @@
 package com.twilio.video.app.ui.room
 
 import com.twilio.audioswitch.AudioDevice
+import com.twilio.video.app.sdk.VideoTrackViewState
 
 sealed class RoomViewEvent {
     object RefreshViewState : RoomViewEvent()
@@ -10,7 +11,7 @@ sealed class RoomViewEvent {
     object DeactivateAudioDevice : RoomViewEvent()
     data class Connect(val identity: String, val roomName: String) : RoomViewEvent()
     data class PinParticipant(val sid: String) : RoomViewEvent()
-    data class ToggleLocalVideo(val sid: String) : RoomViewEvent()
+    data class ToggleLocalVideo(val sid: String, val videoTrackViewState: VideoTrackViewState? = null) : RoomViewEvent()
     data class VideoTrackRemoved(val sid: String) : RoomViewEvent()
     data class ScreenTrackRemoved(val sid: String) : RoomViewEvent()
     object Disconnect : RoomViewEvent()

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -94,7 +94,9 @@ class RoomViewModel(
         Timber.d("View Event: $viewEvent")
 
         when (viewEvent) {
-            is RefreshViewState -> actionOn<RoomViewState> { it }
+            is RefreshViewState -> actionOn<RoomViewState> { currentState ->
+                setState { currentState }
+            }
             is CheckPermissions -> checkLocalMedia()
             is SelectAudioDevice -> {
                 audioSwitch.selectDevice(viewEvent.device)

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -111,7 +111,9 @@ class RoomViewModel(
                 updateParticipantViewState()
             }
             is ToggleLocalVideo -> {
-                participantManager.updateParticipantVideoTrack(viewEvent.sid, null)
+                participantManager.updateParticipantVideoTrack(viewEvent.sid,
+                        viewEvent.videoTrackViewState)
+                updateParticipantViewState()
             }
             is VideoTrackRemoved -> {
                 participantManager.updateParticipantVideoTrack(viewEvent.sid, null)

--- a/app/src/main/res/layout/participant_view_primary.xml
+++ b/app/src/main/res/layout/participant_view_primary.xml
@@ -53,7 +53,7 @@
             android:layout_width="107dp"
             android:layout_height="107dp"
             android:layout_centerInParent="true"
-            android:contentDescription="@string/profile_picture"
+            android:contentDescription="@string/primary_profile_picture"
             app:srcCompat="@drawable/ic_account_circle_white_48px" />
 
         <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -196,6 +196,7 @@
     <string name="audio_toggle">Audio toggle</string>
     <string name="video_logo">Video Logo</string>
     <string name="stats_disabled">Stats disabled</string>
+    <string name="primary_profile_picture">Primary view profile picture</string>
     <string name="profile_picture">Profile picture</string>
     <string name="number">Number</string>
     <string name="settings_screen_bandwidth_profile_mode">Mode</string>

--- a/app/src/test/java/com/twilio/video/app/ui/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/twilio/video/app/ui/room/RoomViewModelTest.kt
@@ -17,6 +17,7 @@ import com.twilio.video.app.ui.room.RoomViewEffect.CheckLocalMedia
 import com.twilio.video.app.ui.room.RoomViewEffect.Disconnected
 import com.twilio.video.app.ui.room.RoomViewEffect.ShowConnectFailureDialog
 import com.twilio.video.app.ui.room.RoomViewEffect.ShowMaxParticipantFailureDialog
+import com.twilio.video.app.ui.room.RoomViewEvent.RefreshViewState
 import com.twilio.video.app.util.PermissionUtil
 import io.reactivex.schedulers.TestScheduler
 import io.uniflow.android.test.TestViewObserver
@@ -190,6 +191,16 @@ class RoomViewModelTest {
                 ShowMaxParticipantFailureDialog,
                 Disconnected,
                 lobbyState())
+    }
+
+    @Test
+    fun `The RefreshViewState event should refresh the view state`() {
+        viewModel.processInput(RefreshViewState)
+
+        testObserver.verifySequence(
+                RoomViewState(),
+                RoomViewState()
+        )
     }
 
     private fun lobbyState() =

--- a/app/src/test/java/com/twilio/video/app/ui/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/twilio/video/app/ui/room/RoomViewModelTest.kt
@@ -18,6 +18,7 @@ import com.twilio.video.app.ui.room.RoomViewEffect.Disconnected
 import com.twilio.video.app.ui.room.RoomViewEffect.ShowConnectFailureDialog
 import com.twilio.video.app.ui.room.RoomViewEffect.ShowMaxParticipantFailureDialog
 import com.twilio.video.app.ui.room.RoomViewEvent.RefreshViewState
+import com.twilio.video.app.ui.room.RoomViewEvent.ToggleLocalVideo
 import com.twilio.video.app.util.PermissionUtil
 import io.reactivex.schedulers.TestScheduler
 import io.uniflow.android.test.TestViewObserver
@@ -201,6 +202,21 @@ class RoomViewModelTest {
                 RoomViewState(),
                 RoomViewState()
         )
+    }
+
+    @Test
+    fun `The ToggleLocalVideo event should update the participant view state`() {
+        val expectedVideoTrack = mock<RemoteVideoTrack>()
+        val expectedTrackViewState = VideoTrackViewState(expectedVideoTrack)
+
+        viewModel.processInput(ToggleLocalVideo(PARTICIPANT_SID, expectedTrackViewState))
+
+        val expectedParticipantViewState = participantViewState.copy(
+                videoTrack = expectedTrackViewState)
+        val updatedParticipant = (viewModel.getCurrentState() as RoomViewState).participantThumbnails?.find {
+            it.sid == PARTICIPANT_SID
+        }
+        assertThat(updatedParticipant, equalTo(expectedParticipantViewState))
     }
 
     private fun lobbyState() =

--- a/ui-test-args.yaml
+++ b/ui-test-args.yaml
@@ -5,7 +5,7 @@ e2e-tests:
   test: app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk
   device:
     - {model: lucye, version: 24}
-    - {model: Pixel2, version: 29}
+    - {model: flame, version: 29}
   test-targets:
     - "annotation com.twilio.video.app.e2eTest.E2ETest"
 
@@ -16,6 +16,6 @@ integration-tests:
   test: app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk
   device:
     - {model: lucye, version: 24}
-    - {model: Pixel2, version: 29}
+    - {model: flame, version: 29}
   test-targets:
     - "annotation com.twilio.video.app.integrationTest.IntegrationTest"

--- a/ui-test-args.yaml
+++ b/ui-test-args.yaml
@@ -5,7 +5,7 @@ e2e-tests:
   test: app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk
   device:
     - {model: lucye, version: 24}
-    - {model: flame, version: 29}
+    - {model: Pixel2, version: 29}
   test-targets:
     - "annotation com.twilio.video.app.e2eTest.E2ETest"
 
@@ -16,6 +16,6 @@ integration-tests:
   test: app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk
   device:
     - {model: lucye, version: 24}
-    - {model: flame, version: 29}
+    - {model: Pixel2, version: 29}
   test-targets:
     - "annotation com.twilio.video.app.integrationTest.IntegrationTest"


### PR DESCRIPTION
## Description

This PR Fixes the following bugs:

1. The camera video is not rendered in the primary view when the app starts.
2. The app crashes when pinning the local participant video thumbnail and turning off the video track.

## Validation

- Passed CI.
- Manual validation on a Huawei P30 Lite and Pixel 4.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
