### PR TITLE
Upgrade AudioSwitch to 1.1.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -168,7 +168,7 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"
     implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0'
-    implementation 'com.twilio:audioswitch:1.0.1'
+    implementation 'com.twilio:audioswitch:1.1.0'
     implementation "io.uniflow:uniflow-androidx:$uniflowVersion"
 
     internalImplementation "com.microsoft.appcenter:appcenter-distribute:2.5.1"

--- a/app/src/main/java/com/twilio/video/app/AudioSwitchModule.kt
+++ b/app/src/main/java/com/twilio/video/app/AudioSwitchModule.kt
@@ -1,6 +1,7 @@
 package com.twilio.video.app
 
 import android.app.Application
+import com.twilio.audioswitch.AudioDevice
 import com.twilio.audioswitch.AudioSwitch
 import dagger.Module
 import dagger.Provides
@@ -10,5 +11,10 @@ class AudioSwitchModule {
 
     @Provides
     fun providesAudioDeviceSelector(application: Application): AudioSwitch =
-            AudioSwitch(application, loggingEnabled = true)
+            AudioSwitch(application,
+                    loggingEnabled = true,
+                    preferredDeviceList = listOf(AudioDevice.BluetoothHeadset::class.java,
+                            AudioDevice.WiredHeadset::class.java,
+                            AudioDevice.Speakerphone::class.java,
+                            AudioDevice.Earpiece::class.java))
 }


### PR DESCRIPTION
### 1.1.0

Enhancements

- Added a constructor parameter named `preferredDeviceList` to configure the order in which audio devices are automatically selected and activated when `selectedAudioDevice` is null.
```kotlin
val audioSwitch = AudioSwitch(application, preferredDeviceList = listOf(Speakerphone::class.java, BluetoothHeadset::class.java))
```
- Updated `compileSdkVersion` and `targetSdkVersion` to Android API version `30`.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
