### PR TITLE
Upgrade Video SDK dependency to 5.12.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'kotlin-kapt'
 def videoAndroidSdkDepProp = "videoAppSdkDependency"
 def videoAndroidSdkDep = (project.hasProperty(videoAndroidSdkDepProp) ?
         project("${project.property(videoAndroidSdkDepProp)}") :
-        "com.twilio:video-android:5.11.1")
+        "com.twilio:video-android:5.12.0")
 def versionCodeProperty = project.property('versionCode') as Integer
 
 android {


### PR DESCRIPTION
## Description

Upgraded the Video SDK dependency to the latest stable version, [5.12.0](https://github.com/twilio/twilio-video-android/releases/tag/5.12.0).

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
