### PR TITLE
Upgrade to video SDK 6.0.0-beta2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'kotlin-kapt'
 def videoAndroidSdkDepProp = "videoAppSdkDependency"
 def videoAndroidSdkDep = (project.hasProperty(videoAndroidSdkDepProp) ?
         project("${project.property(videoAndroidSdkDepProp)}") :
-        "com.twilio:video-android:6.0.0-beta1")
+        "com.twilio:video-android:6.0.0-beta2")
 def versionCodeProperty = project.property('versionCode') as Integer
 
 android {


### PR DESCRIPTION
## 6.0.0-beta2

##### Enhancements

* The SDK API docs now include documentation for classes defined in [tvi.webrtc](https://twilio.github.io/twilio-video-android/docs/6.0.0-beta2/tvi/webrtc/package-frame.html). For example, the `VideoCapturer` API docs will now provide a link to the base interface `tvi.webrtc.VideoCapturer`.
* `isRecording()` API now accurately reflects the current recording state of the `Room`. In the previous versions of the SDK, `isRecording()` could return false positives. The `onRecordingStarted(...)` and `onRecordingStopped(...)` callbacks will now be invoked when recording for at least a single track in the `Room` has started and stopped respectively.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
