### PR TITLE
GSDK-2252: Fix CameraCapturerCompat Crash

### DIFF
--- a/app/src/androidTest/java/com/twilio/video/app/integrationTest/CameraCapturerCompatTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/integrationTest/CameraCapturerCompatTest.kt
@@ -41,14 +41,13 @@ class CameraCapturerCompatTest {
         assertThat(capturerCompat, `is`(not(nullValue())))
 
         capturerCompat?.run {
-            val enumerator = if (capturerCompat.camera2Capturer != null) Camera2Enumerator(getTargetContext()) else Camera1Enumerator()
-            var isFrontFacing = enumerator.isFrontFacing(cameraId)
+            var isFrontFacing = cameraEnumerator.isFrontFacing(cameraId)
             assertThat(isFrontFacing, equalTo(true))
             switchCamera()
-            val isBackFacing = enumerator.isBackFacing(cameraId)
+            val isBackFacing = cameraEnumerator.isBackFacing(cameraId)
             assertThat(isBackFacing, equalTo(true))
             switchCamera()
-            isFrontFacing = enumerator.isFrontFacing(cameraId)
+            isFrontFacing = cameraEnumerator.isFrontFacing(cameraId)
             assertThat(isFrontFacing, equalTo(true))
         }
     }

--- a/app/src/androidTest/java/com/twilio/video/app/integrationTest/CameraCapturerCompatTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/integrationTest/CameraCapturerCompatTest.kt
@@ -41,7 +41,7 @@ class CameraCapturerCompatTest {
         assertThat(capturerCompat, `is`(not(nullValue())))
 
         capturerCompat?.run {
-            val enumerator = Camera2Enumerator(getTargetContext())
+            val enumerator = if (capturerCompat.camera2Capturer != null) Camera2Enumerator(getTargetContext()) else Camera1Enumerator()
             var isFrontFacing = enumerator.isFrontFacing(cameraId)
             assertThat(isFrontFacing, equalTo(true))
             switchCamera()

--- a/app/src/main/java/com/twilio/video/app/util/CameraCapturerCompat.kt
+++ b/app/src/main/java/com/twilio/video/app/util/CameraCapturerCompat.kt
@@ -64,7 +64,7 @@ class CameraCapturerCompat(
                     CameraCapturerCompat(cameraIds.first, cameraIds.second, camera2Capturer = cameraCapturer)
                 }
             } else {
-                Camera1Enumerator().getFrontAndBackCameraIds(context)?.let { cameraIds ->
+                Camera1Enumerator().getFrontAndBackCameraIds(context, isCamera2 = false)?.let { cameraIds ->
                     val cameraCapturer = CameraCapturer(context, cameraIds.first ?: cameraIds.second
                     ?: "")
                     CameraCapturerCompat(cameraIds.first, cameraIds.second, cameraCapturer = cameraCapturer)
@@ -72,15 +72,18 @@ class CameraCapturerCompat(
             }
         }
 
-        private fun CameraEnumerator.getFrontAndBackCameraIds(context: Context): Pair<String?, String?>? {
-            val cameraIds = deviceNames.find { isFrontFacing(it) && isCameraIdSupported(context, it) } to
-                    deviceNames.find { isBackFacing(it) && isCameraIdSupported(context, it) }
+        private fun CameraEnumerator.getFrontAndBackCameraIds(context: Context, isCamera2: Boolean = true): Pair<String?, String?>? {
+            val cameraIds = deviceNames.find { isFrontFacing(it) && isCameraIdSupported(isCamera2, context, it) } to
+                    deviceNames.find { isBackFacing(it) && isCameraIdSupported(isCamera2, context, it) }
             return if (isAtLeastOneCameraAvailable(cameraIds.first, cameraIds.second)) cameraIds
             else {
                 Timber.w("No cameras are available on this device")
                 null
             }
         }
+
+        private fun isCameraIdSupported(isCamera2: Boolean, context: Context, cameraId: String) =
+                if (isCamera2) isCameraIdSupported(context, cameraId) else true
 
         private fun isCameraIdSupported(context: Context, cameraId: String): Boolean {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/app/src/main/java/com/twilio/video/app/util/CameraCapturerCompat.kt
+++ b/app/src/main/java/com/twilio/video/app/util/CameraCapturerCompat.kt
@@ -6,6 +6,8 @@ import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.hardware.camera2.CameraMetadata
 import android.os.Build
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.PRIVATE
 import com.twilio.video.Camera2Capturer
 import com.twilio.video.CameraCapturer
 import com.twilio.video.VideoCapturer
@@ -20,7 +22,8 @@ class CameraCapturerCompat(
     private val frontCameraId: String?,
     private val backCameraId: String?,
     private val cameraCapturer: CameraCapturer? = null,
-    private val camera2Capturer: Camera2Capturer? = null
+    @VisibleForTesting(otherwise = PRIVATE)
+    internal val camera2Capturer: Camera2Capturer? = null
 ) : VideoCapturer {
 
     val cameraId: String

--- a/app/src/main/java/com/twilio/video/app/util/CameraCapturerCompat.kt
+++ b/app/src/main/java/com/twilio/video/app/util/CameraCapturerCompat.kt
@@ -6,7 +6,6 @@ import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.hardware.camera2.CameraMetadata
 import android.os.Build
-import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
 import com.twilio.video.Camera2Capturer
 import com.twilio.video.CameraCapturer
@@ -22,8 +21,7 @@ class CameraCapturerCompat(
     private val frontCameraId: String?,
     private val backCameraId: String?,
     private val cameraCapturer: CameraCapturer? = null,
-    @VisibleForTesting(otherwise = PRIVATE)
-    internal val camera2Capturer: Camera2Capturer? = null
+    private val camera2Capturer: Camera2Capturer? = null
 ) : VideoCapturer {
 
     val cameraId: String
@@ -69,7 +67,13 @@ class CameraCapturerCompat(
             } else {
                 Camera1Enumerator().getFrontAndBackCameraIds(context, isCamera2 = false)?.let { cameraIds ->
                     val cameraCapturer = CameraCapturer(context, cameraIds.first ?: cameraIds.second
-                    ?: "")
+                    ?: "", object : CameraCapturer.Listener {
+                        override fun onFirstFrameAvailable() {}
+
+                        override fun onCameraSwitched(newCameraId: String) {}
+
+                        override fun onError(errorCode: Int) {}
+                    })
                     CameraCapturerCompat(cameraIds.first, cameraIds.second, cameraCapturer = cameraCapturer)
                 }
             }

--- a/app/src/main/java/com/twilio/video/app/util/CameraCapturerCompat.kt
+++ b/app/src/main/java/com/twilio/video/app/util/CameraCapturerCompat.kt
@@ -6,7 +6,6 @@ import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.hardware.camera2.CameraMetadata
 import android.os.Build
-import androidx.annotation.VisibleForTesting.PRIVATE
 import com.twilio.video.Camera2Capturer
 import com.twilio.video.CameraCapturer
 import com.twilio.video.VideoCapturer
@@ -67,16 +66,18 @@ class CameraCapturerCompat(
             } else {
                 Camera1Enumerator().getFrontAndBackCameraIds(context, isCamera2 = false)?.let { cameraIds ->
                     val cameraCapturer = CameraCapturer(context, cameraIds.first ?: cameraIds.second
-                    ?: "", object : CameraCapturer.Listener {
-                        override fun onFirstFrameAvailable() {}
-
-                        override fun onCameraSwitched(newCameraId: String) {}
-
-                        override fun onError(errorCode: Int) {}
-                    })
+                    ?: "", getCameraListener())
                     CameraCapturerCompat(cameraIds.first, cameraIds.second, cameraCapturer = cameraCapturer)
                 }
             }
+        }
+
+        private fun getCameraListener() = object : CameraCapturer.Listener {
+            override fun onFirstFrameAvailable() { }
+
+            override fun onCameraSwitched(newCameraId: String) {}
+
+            override fun onError(errorCode: Int) {}
         }
 
         private fun CameraEnumerator.getFrontAndBackCameraIds(context: Context, isCamera2: Boolean = true): Pair<String?, String?>? {

--- a/ui-test-args.yaml
+++ b/ui-test-args.yaml
@@ -15,8 +15,10 @@ integration-tests:
   app: app/build/outputs/apk/internal/debug/app-internal-debug.apk
   test: app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk
   device:
+    - {model: athene, version: 23}
     - {model: lucye, version: 24}
     - {model: sawfish, version: 26}
+    - {model: albus, version: 26}
     - {model: flame, version: 29}
   test-targets:
     - "annotation com.twilio.video.app.integrationTest.IntegrationTest"


### PR DESCRIPTION
## Description

Fixes a crash when using the `CameraCapturerCompat` from devices using the legacy `CameraCapturer`.

## Validation

- Added legacy `CameraCapturer` compatible devices to FTL.
- Passed CI.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
