### PR TITLE
Update video sdk to 6.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ afterEvaluate {
             debugImplementation project(':video:ktx')
             releaseImplementation project(':video:ktx')
         } else {
-            implementation "com.twilio:video-android-ktx:6.1.0"
+            implementation "com.twilio:video-android-ktx:6.2.0"
         }
     }
 }


### PR DESCRIPTION
### 6.2.0 (January 13th, 2021)

* Programmable Video Android SDK 6.2.0 [[bintray]](https://bintray.com/twilio/releases/video-android/6.2.0), [[docs]](https://twilio.github.io/twilio-video-android/docs/6.2.0/)
* Programmable Video Android SDK KTX 6.2.0 [[bintray]](https://bintray.com/twilio/releases/video-android-ktx/6.2.0), [[docs]](https://twilio.github.io/twilio-video-android/docs/ktx/6.2.0/)

#### Enhancements

* Updated the SDK to Android Gradle Plugin 4.1.1

#### Maintenance

* Removed `tvi.webrtc.NetworkMonitor` and `tvi.webrtc.NetworkMonitorAutoDetect` from the `libwebrtc.jar` since they are unused by the SDK.

Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| x86             | 5.5MB           |
| x86_64          | 5.5MB           |
| armeabi-v7a     | 4.1MB           |
| arm64-v8a       | 5.2MB           |
| universal       | 19.6MB          |