### PR TITLE
Fix Snackbar length lint error

### DIFF
--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
@@ -41,6 +41,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.widget.doOnTextChanged
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.twilio.audioswitch.AudioDevice
 import com.twilio.audioswitch.AudioDevice.BluetoothHeadset
@@ -264,7 +265,7 @@ class RoomActivity : BaseActivity() {
                 Snackbar.make(
                     binding.room.primaryVideo,
                     R.string.screen_capture_permission_not_granted,
-                    Snackbar.LENGTH_LONG)
+                    BaseTransientBottomBar.LENGTH_LONG)
                     .show()
                 return
             }


### PR DESCRIPTION
## Description

Fixed Snackbar length lint error.

## Validation

- Manually validated snackbar appears when denying the screen capture permission
- Passed CI

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
