### PR TITLE
Update video android to 6.2.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ afterEvaluate {
             debugImplementation project(':video:ktx')
             releaseImplementation project(':video:ktx')
         } else {
-            implementation "com.twilio:video-android-ktx:6.2.0"
+            implementation "com.twilio:video-android-ktx:6.2.1"
         }
     }
 }


### PR DESCRIPTION
### 6.2.1

* Programmable Video Android SDK 6.2.1 [[bintray]](https://bintray.com/twilio/releases/video-android/6.2.1), [[docs]](https://twilio.github.io/twilio-video-android/docs/6.2.1/)

#### Bug Fixes

* Fixed a crash that occurred while using either the `CameraCapturer` or `Camera2Capturer`, switching from the front camera to the back camera, and toggling the camera flash.

#### Known issues

* Publishing multiple tracks with the same name results in a crash if network quality is enabled. To avoid this, use unique names for each track in the `Room`.

Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| x86             | 5.5MB           |
| x86_64          | 5.5MB           |
| armeabi-v7a     | 4.1MB           |
| arm64-v8a       | 5.2MB           |
| universal       | 19.6MB          |
