### PR TITLE
Replace Coroutine Channel with SharedFlow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,8 @@ jobs:
           name: Unit Tests
           command: ./gradlew app:testInternalDebugUnitTest
       - save-cache: *save-cache-gradle
+      - store_test_results:
+          path: "~/app/build/test-results"
 
   community-unit-tests:
     <<: *build-defaults
@@ -149,6 +151,8 @@ jobs:
           name: Community Unit Tests
           command: ./gradlew app:testCommunityDebugUnitTest
       - save-cache: *save-cache-gradle
+      - store_test_results:
+          path: "~/app/build/test-results"
 
   e2e-tests:
     <<: *ui-test-defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,8 +135,6 @@ jobs:
           name: Unit Tests
           command: ./gradlew app:testInternalDebugUnitTest
       - save-cache: *save-cache-gradle
-      - store_test_results:
-          path: "~/app/build/test-results"
 
   community-unit-tests:
     <<: *build-defaults
@@ -151,8 +149,6 @@ jobs:
           name: Community Unit Tests
           command: ./gradlew app:testCommunityDebugUnitTest
       - save-cache: *save-cache-gradle
-      - store_test_results:
-          path: "~/app/build/test-results"
 
   e2e-tests:
     <<: *ui-test-defaults

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -149,7 +149,7 @@ dependencies {
     def testCore = "androidx.test:core:$androidXTest"
     def junitExtensions = 'androidx.test.ext:junit-ktx:1.1.1'
     def lifecycleVersion = '2.2.0'
-    def coroutinesAndroidVersion = '1.3.9'
+    def coroutinesAndroidVersion = '1.4.2'
     def fragmentVersion = '1.2.5'
     def uniflowVersion = '0.11.2'
 

--- a/app/src/main/java/com/twilio/video/app/sdk/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/RoomManager.kt
@@ -50,8 +50,8 @@ class RoomManager(
     private val roomListener = RoomListener()
     @VisibleForTesting(otherwise = PRIVATE)
     internal var roomScope = CoroutineScope(coroutineDispatcher)
-    private val mutableRoomState: MutableSharedFlow<RoomEvent> = MutableSharedFlow()
-    val roomState: SharedFlow<RoomEvent> = mutableRoomState
+    private val mutableRoomEvents: MutableSharedFlow<RoomEvent> = MutableSharedFlow()
+    val roomEvents: SharedFlow<RoomEvent> = mutableRoomEvents
     @VisibleForTesting(otherwise = PRIVATE)
     internal var localParticipantManager: LocalParticipantManager =
             LocalParticipantManager(context, this, sharedPreferences)
@@ -80,7 +80,7 @@ class RoomManager(
 
     fun sendRoomEvent(roomEvent: RoomEvent) {
         Timber.d("sendRoomEvent: $roomEvent")
-        roomScope.launch { mutableRoomState.emit(roomEvent) }
+        roomScope.launch { mutableRoomEvents.emit(roomEvent) }
     }
 
     private fun handleTokenException(e: Exception, error: AuthServiceError? = null): Room? {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -2,6 +2,7 @@ package com.twilio.video.app.ui.room
 
 import android.Manifest.permission
 import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.PRIVATE
 import androidx.annotation.VisibleForTesting.PROTECTED
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -81,7 +82,8 @@ class RoomViewModel(
 ) : AndroidDataFlow(defaultState = initialViewState) {
 
     private var permissionCheckRetry = false
-    private var roomManagerJob: Job? = null
+    @VisibleForTesting(otherwise = PRIVATE)
+    internal var roomManagerJob: Job? = null
 
     init {
         audioSwitch.start { audioDevices, selectedDevice ->
@@ -146,7 +148,7 @@ class RoomViewModel(
     }
 
     private fun subscribeToRoomChannel() {
-        roomManager.roomState.let { stateFlow ->
+        roomManager.roomEvents.let { stateFlow ->
             roomManagerJob = viewModelScope.launch {
                 Timber.d("Listening for RoomEvents")
                 stateFlow.collect { observeRoomEvents(it) }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -148,16 +148,8 @@ class RoomViewModel(
     private fun subscribeToRoomChannel() {
         roomManager.roomState.let { stateFlow ->
             viewModelScope.launch {
-                while (isActive) {
-                    Timber.d("Listening for RoomEvents")
-                    try {
-                        stateFlow.collect { observeRoomEvents(it) }
-                    } catch (e: CancellationException) {
-                        Timber.e("Cannot receive(), Receiving coroutine has been canceled")
-                    } catch (e: ClosedReceiveChannelException) {
-                        Timber.e("Cannot receive(), Channel has been closed")
-                    }
-                }
+                Timber.d("Listening for RoomEvents")
+                stateFlow.collect { observeRoomEvents(it) }
             }
         }
     }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -69,6 +69,7 @@ import io.uniflow.core.flow.actionOn
 import io.uniflow.core.flow.data.UIState
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -145,12 +146,12 @@ class RoomViewModel(
     }
 
     private fun subscribeToRoomChannel() {
-        roomManager.roomReceiveChannel.let { channel ->
+        roomManager.roomState.let { stateFlow ->
             viewModelScope.launch {
                 while (isActive) {
                     Timber.d("Listening for RoomEvents")
                     try {
-                        observeRoomEvents(channel.receive())
+                        stateFlow.collect { observeRoomEvents(it) }
                     } catch (e: CancellationException) {
                         Timber.e("Cannot receive(), Receiving coroutine has been canceled")
                     } catch (e: ClosedReceiveChannelException) {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -97,7 +97,7 @@ class RoomViewModel(
             }
         }
 
-        subscribeToRoomChannel()
+        subscribeToRoomEvents()
     }
 
     @VisibleForTesting(otherwise = PROTECTED)
@@ -147,11 +147,11 @@ class RoomViewModel(
         }
     }
 
-    private fun subscribeToRoomChannel() {
-        roomManager.roomEvents.let { stateFlow ->
+    private fun subscribeToRoomEvents() {
+        roomManager.roomEvents.let { sharedFlow ->
             roomManagerJob = viewModelScope.launch {
                 Timber.d("Listening for RoomEvents")
-                stateFlow.collect { observeRoomEvents(it) }
+                sharedFlow.collect { observeRoomEvents(it) }
             }
         }
     }

--- a/app/src/test/java/com/twilio/video/app/ui/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/twilio/video/app/ui/room/RoomViewModelTest.kt
@@ -50,7 +50,7 @@ class RoomViewModelTest : BaseUnitTest() {
     @get:Rule
     val coroutineScope = TestDispatchersRule(testDispatcher)
 
-    val localParticipantManager = mock<LocalParticipantManager>()
+    private val localParticipantManager = mock<LocalParticipantManager>()
     private val roomManager = RoomManager(mock(), mock(), mock(), testDispatcher).apply {
         localParticipantManager = this@RoomViewModelTest.localParticipantManager
     }
@@ -229,6 +229,17 @@ class RoomViewModelTest : BaseUnitTest() {
                 initialRoomViewState.copy(configuration = RoomViewConfiguration.Connecting),
                 initialRoomViewState.copy(configuration = RoomViewConfiguration.Connecting,
                         isRecording = false))
+    }
+
+    @Test
+    fun `OnCleared should cancel room manager job`() {
+        assertThat(viewModel.roomManagerJob!!.isActive, equalTo(true))
+        assertThat(viewModel.roomManagerJob!!.isCancelled, equalTo(false))
+
+        viewModel.onCleared()
+
+        assertThat(viewModel.roomManagerJob!!.isActive, equalTo(false))
+        assertThat(viewModel.roomManagerJob!!.isCancelled, equalTo(true))
     }
 
     private fun connect() =

--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,8 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
-        classpath "com.google.gms:google-services:4.3.4"
+        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath "com.google.gms:google-services:4.3.5"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.30"
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.4.1'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "com.google.gms:google-services:4.3.4"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.21"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.30"
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.4.1'
     }
 }


### PR DESCRIPTION
## Description

Replaced the Kotlin Coroutine Channel with SharedFlow within the RoomManager class to emit video SDK events. SharedFlow is preferred over channels to handle asynchronous streams of events because of it's simplified API and direct compatibility with Flows. If we add additional Flows that the ViewModel consumes, we can perform flow operations like combine to easily integrate multiple streams of events.

This PR also includes an update to the Android Gradle Plugin.

## Validation

- Manually validated video SDK features in the app
- Passed CI

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
