### PR TITLE
Upgrade audioswitch to 1.1.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -182,7 +182,7 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"
     implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0'
-    implementation 'com.twilio:audioswitch:1.1.0'
+    implementation 'com.twilio:audioswitch:1.1.2'
     implementation "io.uniflow:uniflow-androidx:$uniflowVersion"
 
     /*


### PR DESCRIPTION
## AudioSwitch 1.1.2

Enhancements

- Updated the library to use Android Gradle Plugin 4.1.1
- Now published to MavenCentral

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
