### PR TITLE
VIDEO-3725: Chat Integration Layer - Send Message

### DIFF
--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import com.twilio.audioswitch.AudioSwitch
 import com.twilio.video.Participant
 import com.twilio.video.app.chat.ChatManager
+import com.twilio.video.app.chat.ConnectionState
 import com.twilio.video.app.participant.ParticipantManager
 import com.twilio.video.app.participant.buildParticipantViewState
 import com.twilio.video.app.sdk.RoomManager
@@ -100,6 +101,7 @@ class RoomViewModel(
         }
 
         subscribeToRoomEvents()
+        subscribeToChatEvents()
     }
 
     @VisibleForTesting(otherwise = PROTECTED)
@@ -154,6 +156,20 @@ class RoomViewModel(
             roomManagerJob = viewModelScope.launch {
                 Timber.d("Listening for RoomEvents")
                 sharedFlow.collect { observeRoomEvents(it) }
+            }
+        }
+    }
+
+    // Spike code to test send message
+    private fun subscribeToChatEvents() {
+        chatManager.chatState.let { flow ->
+            viewModelScope.launch {
+                Timber.d("Listening for ChatEvents")
+                flow.collect { chatState ->
+                    if (chatState.connectionState == ConnectionState.Connected) {
+                        chatManager.sendMessage("Hello world!")
+                    }
+                }
             }
         }
     }

--- a/chat/src/main/java/com/twilio/video/app/chat/ChatEvent.kt
+++ b/chat/src/main/java/com/twilio/video/app/chat/ChatEvent.kt
@@ -5,4 +5,6 @@ sealed class ChatEvent {
     object ClientSynchronizationFailure : ChatEvent()
     object ConversationJoinFailure : ChatEvent()
     object GetMessagesFailure : ChatEvent()
+    object SendMessageFailure : ChatEvent()
+    data class SendMessageSuccess(val message: ChatMessage) : ChatEvent()
 }

--- a/chat/src/main/java/com/twilio/video/app/chat/ChatManager.kt
+++ b/chat/src/main/java/com/twilio/video/app/chat/ChatManager.kt
@@ -8,5 +8,6 @@ interface ChatManager {
     val chatEvents: Flow<ChatEvent>
 
     fun connect(token: String, chatName: String)
+    fun sendMessage(message: String)
     fun disconnect()
 }

--- a/chat/src/main/java/com/twilio/video/app/chat/ChatManagerImpl.kt
+++ b/chat/src/main/java/com/twilio/video/app/chat/ChatManagerImpl.kt
@@ -66,7 +66,8 @@ class ChatManagerImpl(
                     .withBody(message)
             conversation?.sendMessage(options, sendMessageCallback)
         } else {
-            throw IllegalStateException("Cannot send a message while not in the connected state")
+            throw IllegalStateException("Cannot send a message while not in the connected state. " +
+                    "Current state is: ${chatState.value.connectionState}")
         }
     }
 

--- a/chat/src/main/java/com/twilio/video/app/chat/sdk/MessageWrapper.kt
+++ b/chat/src/main/java/com/twilio/video/app/chat/sdk/MessageWrapper.kt
@@ -1,0 +1,10 @@
+package com.twilio.video.app.chat.sdk
+
+import com.twilio.conversations.Message
+
+class MessageWrapper {
+
+    fun options(): Message.Options {
+        return Message.options()
+    }
+}

--- a/chat/src/test/java/com/twilio/video/app/chat/ChatManagerImplTest.kt
+++ b/chat/src/test/java/com/twilio/video/app/chat/ChatManagerImplTest.kt
@@ -279,17 +279,29 @@ class ChatManagerImplTest {
 
     @Test
     fun `Failing to send a new message should send a failure chat event`() {
-        TODO("Not yet implemented")
+        val options = mock<Message.Options> {
+            whenever(mock.withBody(isA())).thenReturn(mock)
+        }
+        whenever(messageWrapper.options()).thenReturn(options)
+        whenever(conversation.sendMessage(eq(options), isA())).thenAnswer {
+            (it.arguments[1] as CallbackListener<Message>).onError(ErrorInfo(CONVERSATION_NOT_FOUND, TEST_ERROR))
+        }
+        connectClient()
+        val expectedEvents = listOf(
+                ChatEvent.SendMessageFailure
+        )
+        val testEvents = mutableListOf<ChatEvent>()
+        val testChatEventJob = testScope.launch { chatManager.chatEvents.collect { testEvents.add(it) } }
+
+        chatManager.sendMessage(expectedMessages.first().message)
+
+        testChatEventJob.cancel()
+        assertThat(testEvents, equalTo(expectedEvents))
     }
 
     @Test(expected = IllegalStateException::class)
     fun `Sending a new message before connecting should throw an IllegalStateException`() {
-        TODO("Not yet implemented")
-    }
-
-    @Test(expected = IllegalStateException::class)
-    fun `Sending a new message with a null conversation should throw an IllegalStateException`() {
-        TODO("Not yet implemented")
+        chatManager.sendMessage(expectedMessages.first().message)
     }
 
     private fun connectClient() {


### PR DESCRIPTION
## Description

Adds the ability for the `ChatManager` to send a new text message via the conversations SDK.

## Validation

- Validated manually via the rtc video plugin and the community app flavor.
- Passes CI.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
