### PR TITLE
VIDEO-4537: Move mavenCentral() above jcenter()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,8 +50,8 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
         mavenCentral()
+        jcenter()
         maven {
             url  "https://twilio.bintray.com/releases"
         }
@@ -176,8 +176,8 @@ task incrementVersionCode {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
+        jcenter()
         maven {
             url 'https://oss.jfrog.org/artifactory/libs-snapshot/'
         }


### PR DESCRIPTION
## Description

Move mavenCentral() above jcenter() in the project level build.gradle repositories block.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
