### PR TITLE
Add required create_room plugin-rtc request attribute

### DIFF
--- a/app/src/community/java/com/twilio/video/app/data/api/AuthServiceRepository.kt
+++ b/app/src/community/java/com/twilio/video/app/data/api/AuthServiceRepository.kt
@@ -69,10 +69,9 @@ class AuthServiceRepository(
         identity: String?,
         roomName: String?
     ): Pair<AuthServiceRequestDTO, String> {
-        val requestBody = AuthServiceRequestDTO(
-                passcode,
-                identity,
-                roomName)
+        val requestBody = roomName?.let { roomName ->
+            AuthServiceRequestDTO(passcode, identity, roomName, true)
+        } ?: AuthServiceRequestDTO(passcode, identity)
         val appId = passcode.substring(6, 10)
         val serverlessId = passcode.substring(10)
         val url = if (passcode.length == PASSCODE_SIZE) {

--- a/app/src/community/java/com/twilio/video/app/data/api/AuthServiceRequestDTO.kt
+++ b/app/src/community/java/com/twilio/video/app/data/api/AuthServiceRequestDTO.kt
@@ -3,5 +3,6 @@ package com.twilio.video.app.data.api
 data class AuthServiceRequestDTO(
     val passcode: String? = null,
     val user_identity: String? = null,
-    val room_name: String? = null
+    val room_name: String? = null,
+    val create_room: Boolean = false
 )

--- a/app/src/testCommunity/java/com/twilio/video/app/data/api/AuthServiceRepositoryTest.kt
+++ b/app/src/testCommunity/java/com/twilio/video/app/data/api/AuthServiceRepositoryTest.kt
@@ -180,7 +180,7 @@ class AuthServiceRepositoryTest {
             val repository = setupRepository()
             val actualToken = repository.getToken(userIdentity, roomName, passcode)
 
-            verify(authService).getToken(expectedURL, expectedRequestDTO)
+            verify(authService).getToken(expectedURL, expectedRequestDTO.copy(create_room = true))
             assertThat(actualToken, equalTo(token))
         }
     }


### PR DESCRIPTION
## Description

Added required `create_room` plugin-rtc HTTP request attribute as part of the chat feature release changes.

## Validation

- Manually validated community build login and joining a room with another participant

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
