### PR TITLE
Add Advanced Audio Preferences

### DIFF
--- a/app/src/androidTest/java/com/twilio/video/app/integrationTest/PreferenceIntegrationTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/integrationTest/PreferenceIntegrationTest.kt
@@ -58,6 +58,37 @@ class PreferenceIntegrationTest : BaseIntegrationTest() {
     }
 
     @Test
+    fun it_should_assert_correct_default_audio_preferences() {
+        scrollAndClickView(getString(R.string.settings_title_advanced), R.id.recycler_view)
+
+        assertTextIsDisplayedRetry(getString(R.string.settings_title_advanced))
+
+        scrollAndClickView(getString(R.string.settings_title_audio), R.id.recycler_view)
+
+        assertTextIsDisplayedRetry(getString(R.string.settings_title_audio))
+
+        // Use inverse of default as second param to ensure default works from preference screen
+        val sharedPreferences = getSharedPreferences(getTargetContext())
+        val acousticEchoCanceler = sharedPreferences.getBoolean(
+                Preferences.AUDIO_ACOUSTIC_ECHO_CANCELER,
+                !Preferences.AUDIO_ACOUSTIC_ECHO_CANCELER_DEFAULT)
+        val noiseSuppressor = sharedPreferences.getBoolean(
+                Preferences.AUDIO_ACOUSTIC_NOISE_SUPRESSOR,
+                !Preferences.AUDIO_ACOUSTIC_NOISE_SUPRESSOR_DEFAULT)
+        val automaticGainControl = sharedPreferences.getBoolean(
+                Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL,
+                !Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL_DEFAULT)
+        val openSLESUsage = sharedPreferences.getBoolean(
+                Preferences.AUDIO_OPEN_SLES_USAGE,
+                !Preferences.AUDIO_OPEN_SLES_USAGE_DEFAULT)
+
+        assertThat(acousticEchoCanceler, equalTo(Preferences.AUDIO_ACOUSTIC_ECHO_CANCELER_DEFAULT))
+        assertThat(noiseSuppressor, equalTo(Preferences.AUDIO_ACOUSTIC_NOISE_SUPRESSOR_DEFAULT))
+        assertThat(automaticGainControl, equalTo(Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL_DEFAULT))
+        assertThat(openSLESUsage, equalTo(Preferences.AUDIO_OPEN_SLES_USAGE_DEFAULT))
+    }
+
+    @Test
     fun it_should_select_the_correct_topology() {
         scrollAndClickView(getString(R.string.settings_title_advanced), R.id.recycler_view)
 

--- a/app/src/main/java/com/twilio/video/app/data/Preferences.kt
+++ b/app/src/main/java/com/twilio/video/app/data/Preferences.kt
@@ -85,4 +85,12 @@ object Preferences {
     const val BANDWIDTH_PROFILE_STANDARD_TRACK_PRIORITY_RENDER_DIMENSIONS_DEFAULT = SERVER_DEFAULT
     const val BANDWIDTH_PROFILE_HIGH_TRACK_PRIORITY_RENDER_DIMENSIONS = "pref_bandwidth_profile_high_track_priority_dimensions"
     const val BANDWIDTH_PROFILE_HIGH_TRACK_PRIORITY_RENDER_DIMENSIONS_DEFAULT = SERVER_DEFAULT
+    const val AUDIO_ACOUSTIC_ECHO_CANCELER = "pref_audio_acoustic_echo_canceler"
+    const val AUDIO_ACOUSTIC_ECHO_CANCELER_DEFAULT = true
+    const val AUDIO_ACOUSTIC_NOISE_SUPRESSOR = "pref_noise_supressor"
+    const val AUDIO_ACOUSTIC_NOISE_SUPRESSOR_DEFAULT = true
+    const val AUDIO_AUTOMATIC_GAIN_CONTROL = "pref_audio_automatic_gain_control"
+    const val AUDIO_AUTOMATIC_GAIN_CONTROL_DEFAULT = true
+    const val AUDIO_OPEN_SLES_USAGE = "pref_audio_open_sles_usage"
+    const val AUDIO_OPEN_SLES_USAGE_DEFAULT = false
 }

--- a/app/src/main/java/com/twilio/video/app/data/Preferences.kt
+++ b/app/src/main/java/com/twilio/video/app/data/Preferences.kt
@@ -31,9 +31,11 @@ object Preferences {
     const val ENVIRONMENT = "pref_environment"
     const val ENVIRONMENT_DEFAULT = BuildConfig.ENVIRONMENT_DEFAULT
     const val TOPOLOGY = "pref_topology"
+    const val QCIF_VIDEO_WIDTH = 176
+    const val QCIF_VIDEO_HEIGHT = 144
     val TOPOLOGY_DEFAULT: String = Topology.GROUP.value
     val VIDEO_DIMENSIONS = arrayOf(
-            VideoDimensions(176, 144),
+            VideoDimensions(QCIF_VIDEO_WIDTH, QCIF_VIDEO_HEIGHT),
             VideoDimensions.CIF_VIDEO_DIMENSIONS,
             VideoDimensions.VGA_VIDEO_DIMENSIONS,
             VideoDimensions.WVGA_VIDEO_DIMENSIONS,

--- a/app/src/main/java/com/twilio/video/app/data/Preferences.kt
+++ b/app/src/main/java/com/twilio/video/app/data/Preferences.kt
@@ -33,7 +33,7 @@ object Preferences {
     const val TOPOLOGY = "pref_topology"
     val TOPOLOGY_DEFAULT: String = Topology.GROUP.value
     val VIDEO_DIMENSIONS = arrayOf(
-            VideoDimensions.CIF_VIDEO_DIMENSIONS,
+            VideoDimensions(176, 144),
             VideoDimensions.VGA_VIDEO_DIMENSIONS,
             VideoDimensions.WVGA_VIDEO_DIMENSIONS,
             VideoDimensions.HD_540P_VIDEO_DIMENSIONS,

--- a/app/src/main/java/com/twilio/video/app/data/Preferences.kt
+++ b/app/src/main/java/com/twilio/video/app/data/Preferences.kt
@@ -34,6 +34,7 @@ object Preferences {
     val TOPOLOGY_DEFAULT: String = Topology.GROUP.value
     val VIDEO_DIMENSIONS = arrayOf(
             VideoDimensions(176, 144),
+            VideoDimensions.CIF_VIDEO_DIMENSIONS,
             VideoDimensions.VGA_VIDEO_DIMENSIONS,
             VideoDimensions.WVGA_VIDEO_DIMENSIONS,
             VideoDimensions.HD_540P_VIDEO_DIMENSIONS,

--- a/app/src/main/java/com/twilio/video/app/sdk/ConnectOptionsFactory.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/ConnectOptionsFactory.kt
@@ -112,10 +112,10 @@ class ConnectOptionsFactory(
         val openSLESUsage = sharedPreferences.getBoolean(
                 Preferences.AUDIO_OPEN_SLES_USAGE,
                 Preferences.AUDIO_OPEN_SLES_USAGE_DEFAULT)
-        WebRtcAudioUtils.setWebRtcBasedAcousticEchoCanceler(acousticEchoCanceler)
-        WebRtcAudioUtils.setWebRtcBasedNoiseSuppressor(noiseSuppressor)
-        WebRtcAudioUtils.setWebRtcBasedAutomaticGainControl(automaticGainControl)
-        WebRtcAudioManager.setBlacklistDeviceForOpenSLESUsage(openSLESUsage)
+        WebRtcAudioUtils.setWebRtcBasedAcousticEchoCanceler(!acousticEchoCanceler)
+        WebRtcAudioUtils.setWebRtcBasedNoiseSuppressor(!noiseSuppressor)
+        WebRtcAudioUtils.setWebRtcBasedAutomaticGainControl(!automaticGainControl)
+        WebRtcAudioManager.setBlacklistDeviceForOpenSLESUsage(!openSLESUsage)
 
         val isNetworkQualityEnabled = sharedPreferences.get(
                 Preferences.ENABLE_NETWORK_QUALITY_LEVEL,

--- a/app/src/main/java/com/twilio/video/app/sdk/ConnectOptionsFactory.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/ConnectOptionsFactory.kt
@@ -27,6 +27,9 @@ import com.twilio.video.app.util.EnvUtil
 import com.twilio.video.app.util.get
 import com.twilio.video.ktx.createBandwidthProfileOptions
 import com.twilio.video.ktx.createConnectOptions
+import tvi.webrtc.voiceengine.WebRtcAudioManager
+import tvi.webrtc.voiceengine.WebRtcAudioManager.setBlacklistDeviceForOpenSLESUsage
+import tvi.webrtc.voiceengine.WebRtcAudioUtils
 
 class ConnectOptionsFactory(
     private val context: Context,
@@ -96,6 +99,23 @@ class ConnectOptionsFactory(
             trackSwitchOffMode(trackSwitchOffMode)
             renderDimensions(renderDimensions)
         }
+
+        val acousticEchoCanceler = sharedPreferences.getBoolean(
+                Preferences.AUDIO_ACOUSTIC_ECHO_CANCELER,
+                Preferences.AUDIO_ACOUSTIC_ECHO_CANCELER_DEFAULT)
+        val noiseSuppressor = sharedPreferences.getBoolean(
+                Preferences.AUDIO_ACOUSTIC_NOISE_SUPRESSOR,
+                Preferences.AUDIO_ACOUSTIC_NOISE_SUPRESSOR_DEFAULT)
+        val automaticGainControl = sharedPreferences.getBoolean(
+                Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL,
+                Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL_DEFAULT)
+        val openSLESUsage = sharedPreferences.getBoolean(
+                Preferences.AUDIO_OPEN_SLES_USAGE,
+                Preferences.AUDIO_OPEN_SLES_USAGE_DEFAULT)
+        WebRtcAudioUtils.setWebRtcBasedAcousticEchoCanceler(acousticEchoCanceler)
+        WebRtcAudioUtils.setWebRtcBasedNoiseSuppressor(noiseSuppressor)
+        WebRtcAudioUtils.setWebRtcBasedAutomaticGainControl(automaticGainControl)
+        WebRtcAudioManager.setBlacklistDeviceForOpenSLESUsage(openSLESUsage)
 
         val isNetworkQualityEnabled = sharedPreferences.get(
                 Preferences.ENABLE_NETWORK_QUALITY_LEVEL,

--- a/app/src/main/java/com/twilio/video/app/sdk/ConnectOptionsFactory.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/ConnectOptionsFactory.kt
@@ -28,7 +28,6 @@ import com.twilio.video.app.util.get
 import com.twilio.video.ktx.createBandwidthProfileOptions
 import com.twilio.video.ktx.createConnectOptions
 import tvi.webrtc.voiceengine.WebRtcAudioManager
-import tvi.webrtc.voiceengine.WebRtcAudioManager.setBlacklistDeviceForOpenSLESUsage
 import tvi.webrtc.voiceengine.WebRtcAudioUtils
 
 class ConnectOptionsFactory(

--- a/app/src/main/java/com/twilio/video/app/ui/settings/AudioSettingsFragment.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/settings/AudioSettingsFragment.kt
@@ -7,5 +7,7 @@ class AudioSettingsFragment : BaseSettingsFragment() {
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.audio_preferences)
+
+        setHasOptionsMenu(true)
     }
 }

--- a/app/src/main/java/com/twilio/video/app/ui/settings/AudioSettingsFragment.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/settings/AudioSettingsFragment.kt
@@ -1,0 +1,11 @@
+package com.twilio.video.app.ui.settings
+
+import android.os.Bundle
+import com.twilio.video.app.R
+
+class AudioSettingsFragment : BaseSettingsFragment() {
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        addPreferencesFromResource(R.xml.audio_preferences)
+    }
+}

--- a/app/src/main/res/layout/participant_primary_view.xml
+++ b/app/src/main/res/layout/participant_primary_view.xml
@@ -36,51 +36,39 @@
 
     <!-- RemoteParticipant layout with video track -->
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/video_layout"
+        android:background="@color/participantSelectedBackground"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="match_parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/video_layout"
-            android:background="@color/participantSelectedBackground"
-            android:layout_weight="1"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
+        <com.twilio.video.VideoTextureView
+            android:id="@+id/video"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
 
-            <com.twilio.video.VideoTextureView
-                android:id="@+id/video"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"/>
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/video_identity"
+            android:layout_width="140dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:textColor="@android:color/white"
+            android:textSize="14sp"
+            tools:text="Some Identity"
+            android:background="@drawable/badge_background"
+            android:padding="10dp"
+            android:layout_marginTop="100dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginStart="16dp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/video_identity"
-                android:layout_width="140dp"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:textColor="@android:color/white"
-                android:textSize="14sp"
-                tools:text="Some Identity"
-                android:background="@drawable/badge_background"
-                android:padding="10dp"
-                android:layout_marginTop="100dp"
-                android:layout_marginLeft="16dp"
-                android:layout_marginStart="16dp"
-                android:maxLines="1"
-                android:ellipsize="end"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <ImageView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@android:color/black"
-            android:layout_weight="1"/>
-    </LinearLayout>
 </FrameLayout>

--- a/app/src/main/res/layout/participant_primary_view.xml
+++ b/app/src/main/res/layout/participant_primary_view.xml
@@ -36,39 +36,51 @@
 
     <!-- RemoteParticipant layout with video track -->
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/video_layout"
-        android:background="@color/participantSelectedBackground"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-        <com.twilio.video.VideoTextureView
-            android:id="@+id/video"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/video_layout"
+            android:background="@color/participantSelectedBackground"
+            android:layout_weight="1"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/video_identity"
-            android:layout_width="140dp"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:textColor="@android:color/white"
-            android:textSize="14sp"
-            tools:text="Some Identity"
-            android:background="@drawable/badge_background"
-            android:padding="10dp"
-            android:layout_marginTop="100dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:maxLines="1"
-            android:ellipsize="end"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            <com.twilio.video.VideoTextureView
+                android:id="@+id/video"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"/>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/video_identity"
+                android:layout_width="140dp"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textColor="@android:color/white"
+                android:textSize="14sp"
+                tools:text="Some Identity"
+                android:background="@drawable/badge_background"
+                android:padding="10dp"
+                android:layout_marginTop="100dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginStart="16dp"
+                android:maxLines="1"
+                android:ellipsize="end"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"/>
 
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@android:color/black"
+            android:layout_weight="1"/>
+    </LinearLayout>
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,6 +104,7 @@
     <string name="settings_title_advanced">Advanced</string>
     <string name="settings_title_internal">Internal</string>
     <string name="settings_title_bandwidth_profile">Bandwidth Profile</string>
+    <string name="settings_title_audio">Audio</string>
     <string name="username">Username</string>
     <string name="join_room">Join Room</string>
     <string name="registering">Registering</string>
@@ -172,4 +173,8 @@
     <string name="settings_screen_bandwidth_profile_low_track_priority">Low Track Priority</string>
     <string name="settings_screen_bandwidth_profile_standard_track_priority">Standard Track Priority</string>
     <string name="settings_screen_bandwidth_profile_high_track_priority">High Track Priority</string>
+    <string name="settings_screen_audio_acoustic_echo_canceler">Enable Acoustic Echo Canceler</string>
+    <string name="settings_screen_audio_noise_supressor">Enable Noise Supressor</string>
+    <string name="settings_screen_audio_automatic_gain_control">Enable Automatic Gain Control</string>
+    <string name="settings_screen_audio_open_sles_usage">Enable Open SLES Usage</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,8 +173,8 @@
     <string name="settings_screen_bandwidth_profile_low_track_priority">Low Track Priority</string>
     <string name="settings_screen_bandwidth_profile_standard_track_priority">Standard Track Priority</string>
     <string name="settings_screen_bandwidth_profile_high_track_priority">High Track Priority</string>
-    <string name="settings_screen_audio_acoustic_echo_canceler">Enable Acoustic Echo Canceler</string>
-    <string name="settings_screen_audio_noise_supressor">Enable Noise Supressor</string>
-    <string name="settings_screen_audio_automatic_gain_control">Enable Automatic Gain Control</string>
+    <string name="settings_screen_audio_acoustic_echo_canceler">Enable Hardware Acoustic Echo Canceler</string>
+    <string name="settings_screen_audio_noise_supressor">Enable Hardware Noise Supressor</string>
+    <string name="settings_screen_audio_automatic_gain_control">Enable Hardware Automatic Gain Control</string>
     <string name="settings_screen_audio_open_sles_usage">Enable Open SLES Usage</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,8 +173,8 @@
     <string name="settings_screen_bandwidth_profile_low_track_priority">Low Track Priority</string>
     <string name="settings_screen_bandwidth_profile_standard_track_priority">Standard Track Priority</string>
     <string name="settings_screen_bandwidth_profile_high_track_priority">High Track Priority</string>
-    <string name="settings_screen_audio_acoustic_echo_canceler">Enable Hardware Acoustic Echo Canceler</string>
-    <string name="settings_screen_audio_noise_supressor">Enable Hardware Noise Supressor</string>
-    <string name="settings_screen_audio_automatic_gain_control">Enable Hardware Automatic Gain Control</string>
-    <string name="settings_screen_audio_open_sles_usage">Enable Open SLES Usage</string>
+    <string name="settings_screen_audio_acoustic_echo_canceler">Hardware Acoustic Echo Canceler</string>
+    <string name="settings_screen_audio_noise_supressor">Hardware Noise Supressor</string>
+    <string name="settings_screen_audio_automatic_gain_control">Hardware Automatic Gain Control</string>
+    <string name="settings_screen_audio_open_sles_usage">Open SLES Usage</string>
 </resources>

--- a/app/src/main/res/xml/advanced_preferences.xml
+++ b/app/src/main/res/xml/advanced_preferences.xml
@@ -83,6 +83,11 @@
             app:fragment="com.twilio.video.app.ui.settings.BandwidthProfileSettingsFragment"
             app:iconSpaceReserved="false">
         </Preference>
+`       <Preference
+            android:title="@string/settings_title_audio"
+            app:fragment="com.twilio.video.app.ui.settings.AudioSettingsFragment"
+            app:iconSpaceReserved="false">
+        </Preference>
     </PreferenceCategory>
     <PreferenceCategory>
         <Preference

--- a/app/src/main/res/xml/audio_preferences.xml
+++ b/app/src/main/res/xml/audio_preferences.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <CheckBoxPreference
+        android:key="pref_audio_acoustic_echo_canceler"
+        android:title="@string/settings_screen_audio_acoustic_echo_canceler"
+        android:defaultValue="true"
+        app:iconSpaceReserved="false"/>
+
+    <CheckBoxPreference
+        android:key="pref_noise_supressor"
+        android:title="@string/settings_screen_audio_noise_supressor"
+        android:defaultValue="true"
+        app:iconSpaceReserved="false"/>
+
+    <CheckBoxPreference
+        android:key="pref_audio_automatic_gain_control"
+        android:title="@string/settings_screen_audio_automatic_gain_control"
+        android:defaultValue="true"
+        app:iconSpaceReserved="false"/>
+
+    <CheckBoxPreference
+        android:key="pref_audio_open_sles_usage"
+        android:title="@string/settings_screen_audio_open_sles_usage"
+        android:defaultValue="false"
+        app:iconSpaceReserved="false"/>
+</PreferenceScreen>

--- a/app/src/main/res/xml/audio_preferences.xml
+++ b/app/src/main/res/xml/audio_preferences.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:title="@string/settings_title_audio"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <CheckBoxPreference


### PR DESCRIPTION
## Description

Added advanced audio preferences. The preferences toggle the following WebRTC APIs:

```kotlin
WebRtcAudioUtils.setWebRtcBasedAcousticEchoCanceler(preference)
WebRtcAudioUtils.setWebRtcBasedNoiseSuppressor(preference)
WebRtcAudioUtils.setWebRtcBasedAutomaticGainControl(preference)
WebRtcAudioManager.setBlacklistDeviceForOpenSLESUsage(preference)
```

![image](https://user-images.githubusercontent.com/2661383/115898682-7180a900-a423-11eb-85d5-ff301584de47.png)

## Validation

- Passes CI.
- Manually validated preferences.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
