### PR TITLE
Move record control preference to internal flavor only

### DIFF
--- a/app/src/main/res/xml/advanced_preferences.xml
+++ b/app/src/main/res/xml/advanced_preferences.xml
@@ -19,12 +19,6 @@
             android:defaultValue="true"
             app:iconSpaceReserved="false"/>
         <CheckBoxPreference
-            android:key="pref_record_participants_on_connect"
-            android:title="@string/settings_screen_record_participants_on_connect"
-            android:defaultValue="false"
-            app:iconSpaceReserved="false"
-            />
-        <CheckBoxPreference
             android:key="pref_enable_automatic_subscription"
             android:title="@string/settings_screen_enable_automatic_track_subscription"
             android:defaultValue="true"

--- a/app/src/main/res/xml/internal_preferences.xml
+++ b/app/src/main/res/xml/internal_preferences.xml
@@ -16,4 +16,10 @@
         android:title="@string/settings_screen_topology"
         android:negativeButtonText="@null"
         app:iconSpaceReserved="false"/>
+    <CheckBoxPreference
+        android:key="pref_record_participants_on_connect"
+        android:title="@string/settings_screen_record_participants_on_connect"
+        android:defaultValue="false"
+        app:iconSpaceReserved="false"
+        />
 </PreferenceScreen>


### PR DESCRIPTION
## Description

Moved record control preference to internal flavor only as reported in #209 .

## Validation

- Manually tested both app build flavors.
- Passes CI.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
