### PR TITLE
VIDEO-5215: Update the Ahoy App to consume Client Track Switch Off Control

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -164,7 +164,7 @@ dependencies {
     implementation "androidx.preference:preference-ktx:1.1.1"
     implementation "androidx.core:core-ktx:1.3.2"
     implementation "androidx.lifecycle:lifecycle-service:$lifecycleVersion"
-    implementation "androidx.lifecycle:lifecycle-livedata:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
     implementation "androidx.fragment:fragment-ktx:$fragmentVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
     implementation 'com.jakewharton.timber:timber:4.7.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ afterEvaluate {
             debugImplementation project(':video:ktx')
             releaseImplementation project(':video:ktx')
         } else {
-            implementation "com.twilio:video-android-ktx:6.3.0"
+            implementation "com.twilio:video-android-ktx:6.4.0-rc1"
         }
     }
 }
@@ -139,7 +139,7 @@ android {
 }
 
 dependencies {
-    def daggerVersion = '2.28.3'
+    def daggerVersion = '2.35.1'
     def daggerAndroidProcessor = "com.google.dagger:dagger-android-processor:$daggerVersion"
     def daggerCompiler = "com.google.dagger:dagger-compiler:$daggerVersion"
     def retrofitVersion = '2.9.0'

--- a/app/src/main/java/com/twilio/video/app/sdk/ConnectOptionsFactory.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/ConnectOptionsFactory.kt
@@ -67,8 +67,6 @@ class ConnectOptionsFactory(
         val maxSubscriptionBitrate = sharedPreferences.get(Preferences.BANDWIDTH_PROFILE_MAX_SUBSCRIPTION_BITRATE,
                 Preferences.BANDWIDTH_PROFILE_MAX_SUBSCRIPTION_BITRATE_DEFAULT).toLong()
 
-        val maxVideoTracks = sharedPreferences.get(Preferences.BANDWIDTH_PROFILE_MAX_VIDEO_TRACKS,
-                Preferences.BANDWIDTH_PROFILE_MAX_VIDEO_TRACKS_DEFAULT).toLong()
         val dominantSpeakerPriority = sharedPreferences.get(Preferences.BANDWIDTH_PROFILE_DOMINANT_SPEAKER_PRIORITY,
                 Preferences.BANDWIDTH_PROFILE_DOMINANT_SPEAKER_PRIORITY_DEFAULT)?.let {
             getDominantSpeakerPriority(it)
@@ -93,7 +91,6 @@ class ConnectOptionsFactory(
         val bandwidthProfileOptions = createBandwidthProfileOptions {
             mode(mode)
             maxSubscriptionBitrate(maxSubscriptionBitrate)
-            maxTracks(maxVideoTracks)
             dominantSpeakerPriority(dominantSpeakerPriority)
             trackSwitchOffMode(trackSwitchOffMode)
             renderDimensions(renderDimensions)

--- a/app/src/main/java/com/twilio/video/app/ui/room/ParticipantView.java
+++ b/app/src/main/java/com/twilio/video/app/ui/room/ParticipantView.java
@@ -37,10 +37,8 @@ import com.twilio.video.VideoTrack;
 import com.twilio.video.app.R;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import tvi.webrtc.VideoFrame;
-import tvi.webrtc.VideoSink;
 
-abstract class ParticipantView extends FrameLayout implements VideoSink {
+abstract class ParticipantView extends FrameLayout {
 
     private static final VideoScaleType DEFAULT_VIDEO_SCALE_TYPE = VideoScaleType.ASPECT_FIT;
 
@@ -142,9 +140,8 @@ abstract class ParticipantView extends FrameLayout implements VideoSink {
         if (pinImage != null) pinImage.setVisibility(pinned ? VISIBLE : GONE);
     }
 
-    @Override
-    public void onFrame(VideoFrame videoFrame) {
-        videoView.onFrame(videoFrame);
+    public VideoTextureView getVideoTextureView() {
+        return videoView;
     }
 
     void initParams(Context context, AttributeSet attrs) {

--- a/app/src/main/java/com/twilio/video/app/ui/room/ParticipantViewHolder.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/ParticipantViewHolder.kt
@@ -51,11 +51,11 @@ internal class ParticipantViewHolder(private val thumb: ParticipantThumbView) :
             val videoTrackViewState = participantViewState.videoTrack
             val newVideoTrack = videoTrackViewState?.let { it.videoTrack }
             if (videoTrack !== newVideoTrack) {
-                removeRender(videoTrack, this)
+                removeSink(videoTrack, this)
                 videoTrack = newVideoTrack
                 videoTrack?.let { videoTrack ->
                     setVideoState(videoTrackViewState)
-                    if (videoTrack.isEnabled) videoTrack.addSink(this)
+                    if (videoTrack.isEnabled) videoTrack.addSink(this.videoTextureView)
                 } ?: setState(ParticipantView.State.NO_VIDEO)
             } else {
                 setVideoState(videoTrackViewState)
@@ -72,9 +72,9 @@ internal class ParticipantViewHolder(private val thumb: ParticipantThumbView) :
         }
     }
 
-    private fun removeRender(videoTrack: VideoTrack?, view: ParticipantView) {
-        if (videoTrack == null || !videoTrack.sinks.contains(view)) return
-        videoTrack.removeSink(view)
+    private fun removeSink(videoTrack: VideoTrack?, view: ParticipantView) {
+        if (videoTrack == null || !videoTrack.sinks.contains(view.videoTextureView)) return
+        videoTrack.removeSink(view.videoTextureView)
     }
 
     private fun setNetworkQualityLevelImage(

--- a/build.gradle
+++ b/build.gradle
@@ -42,10 +42,10 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath "com.google.gms:google-services:4.3.5"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.2'
+        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath "com.google.gms:google-services:4.3.8"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.6.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,44 +8,21 @@ buildscript {
     ext.releaseKeyPassword = (project.hasProperty('androidReleaseKeyPassword') ?
             project.property('androidReleaseKeyPassword') : 'fakepassword')
 
-    ext.getBintrayUsername = {
-        def bintrayUsername  = System.getenv("BINTRAY_USERNAME")
-
-        if (bintrayUsername == null) {
-            logger.log(LogLevel.INFO, "Could not locate BINTRAY_USERNAME environment variable. " +
+    ext.getPropertyValue =  { propertyKey ->
+        def property  = System.getenv(propertyKey)
+        if (property == null) {
+            logger.log(LogLevel.INFO, "Could not locate $propertyKey as environment variable. " +
                     "Trying local.properties")
             Properties properties = new Properties()
             if (project.rootProject.file('local.properties').exists()) {
                 properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                bintrayUsername = properties.getProperty('BINTRAY_USERNAME')
+                property = properties.getProperty(propertyKey)
             }
         }
-
-        if (bintrayUsername == null) {
-            logger.log(LogLevel.WARN, "Bintray username unavailable.")
+        if (property == null) {
+            logger.log(LogLevel.WARN, "$propertyKey unavailable.")
         }
-
-        return bintrayUsername
-    }
-
-    ext.getBintrayPassword = {
-        def bintrayPassword  = System.getenv("BINTRAY_PASSWORD")
-
-        if (bintrayPassword == null) {
-            logger.log(LogLevel.INFO, "Could not locate BINTRAY_PASSWORD environment variable. " +
-                    "Trying local.properties")
-            Properties properties = new Properties()
-            if (project.rootProject.file('local.properties').exists()) {
-                properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                bintrayPassword = properties.getProperty('BINTRAY_PASSWORD')
-            }
-        }
-
-        if (bintrayPassword == null) {
-            logger.log(LogLevel.WARN, "Bintray password unavailable.")
-        }
-
-        return bintrayPassword
+        return property
     }
 
     repositories {
@@ -53,20 +30,14 @@ buildscript {
         mavenCentral()
         jcenter()
         maven {
-            url  "https://twilio.bintray.com/releases"
-        }
-        maven {
-            url  "https://twilio.bintray.com/internal-releases"
+            url  "https://twilio.jfrog.io/artifactory/internal-releases"
             credentials {
-                username "${getBintrayUsername()}"
-                password "${getBintrayPassword()}"
+                username "${getPropertyValue('ARTIFACTORY_USERNAME')}"
+                password "${getPropertyValue('ARTIFACTORY_PASSWORD')}"
             }
-        }
-        maven {
-            url  "https://twilio.bintray.com/snapshots"
-            credentials {
-                username "${getBintrayUsername()}"
-                password "${getBintrayPassword()}"
+            metadataSources {
+                mavenPom()
+                artifact()
             }
         }
     }
@@ -182,20 +153,14 @@ allprojects {
             url 'https://oss.jfrog.org/artifactory/libs-snapshot/'
         }
         maven {
-            url  "https://twilio.bintray.com/releases"
-        }
-        maven {
-            url  "https://twilio.bintray.com/internal-releases"
+            url  "https://twilio.jfrog.io/artifactory/internal-releases"
             credentials {
-                username "${getBintrayUsername()}"
-                password "${getBintrayPassword()}"
+                username "${getPropertyValue('ARTIFACTORY_USERNAME')}"
+                password "${getPropertyValue('ARTIFACTORY_PASSWORD')}"
             }
-        }
-        maven {
-            url  "https://twilio.bintray.com/snapshots"
-            credentials {
-                username "${getBintrayUsername()}"
-                password "${getBintrayPassword()}"
+            metadataSources {
+                mavenPom()
+                artifact()
             }
         }
         maven {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,3 @@
 versionCode=95
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
## Description

Made changes to consume the Client Track Switch Off feature from the Android Video SDK.

## Breakdown

- The `VideoTextureView` property is exposed in the `ParticipantView` to add as a `RemoteVideoTrack` sink to benefit from the client track switch off auto mode.
- Fixed a bug in `PrimaryParticipantController` where a new sink was added every time even for the same video track.
- Updated the Gradle plugins and a couple of app dependencies.
- Replaced the internal bintray repository with artifactory to consume Video SDK RCs.

## Validation

- Manually validated that tracks are switched on an off as expected with the new SDK feature.
- Passes CI.

## Additional Notes

There will be a follow up ticket to fix an issue in the SDK where switch offs do not occur when a view is detached from a ViewGroup.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
