### PR TITLE
Video Android 6.3.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ afterEvaluate {
             debugImplementation project(':video:ktx')
             releaseImplementation project(':video:ktx')
         } else {
-            implementation "com.twilio:video-android-ktx:6.3.0"
+            implementation "com.twilio:video-android-ktx:6.3.1"
         }
     }
 }


### PR DESCRIPTION
## 6.3.1

#### Bug Fixes
* Fixed a crash (see stacktrace below) that sometimes occurs on Pixel devices when decoding VP8 video streams.
```
java.lang.IllegalArgumentException: Texture width must be positive, but was 0
     FATAL EXCEPTION: AndroidVideoDecoder.outputThread
Process: com.twilio.video.test, PID: 13001
java.lang.IllegalArgumentException: Texture width must be positive, but was 0
    at tvi.webrtc.SurfaceTextureHelper.setTextureSize(SurfaceTextureHelper.java:256)
    at tvi.webrtc.AndroidVideoDecoder.deliverTextureFrame(AndroidVideoDecoder.java:432)
    at tvi.webrtc.AndroidVideoDecoder.deliverDecodedFrame(AndroidVideoDecoder.java:407)
    at tvi.webrtc.AndroidVideoDecoder$1.run(AndroidVideoDecoder.java:369)
```
* Fixed a bug that could cause a crash when changing log level to Trace at runtime.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in ```versionName``` under `app/build.gradle`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
