### PR TITLE
Fix version code bump script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,25 +200,6 @@ jobs:
             - app/build
       - save-cache: *save-cache-gradle
 
-  test-job:
-    <<: *build-defaults
-    resource_class: large
-    steps:
-      - checkout
-      - attach_workspace:
-          at: *workspace
-      - restore-cache: *restore-cache-gradle
-      - run: *get-secrets
-      - run: *configure-git-user
-      - run:
-          name: Increment Version Code
-          command: ./gradlew incrementVersionCode
-      - persist_to_workspace:
-          root: .
-          paths:
-            - app/build
-      - save-cache: *save-cache-gradle
-
   publish-to-appcenter:
     <<: *build-defaults
     resource_class: medium+
@@ -240,38 +221,36 @@ workflows:
 
   build-test:
     jobs:
-      - test-job:
+      - lint:
           <<: *build-test-filter
-#      - lint:
-#          <<: *build-test-filter
-#      - check-format:
-#          <<: *build-test-filter
-#      - build-app:
-#          <<: *build-test-filter
-#      - unit-tests:
-#          <<: *build-test-filter
-#          requires:
-#            - build-app
-#            - lint
-#            - check-format
-#      - community-unit-tests:
-#          <<: *build-test-filter
-#          requires:
-#            - build-app
-#            - lint
-#            - check-format
-#      - e2e-tests:
-#          <<: *build-test-filter
-#          requires:
-#            - build-app
-#            - lint
-#            - check-format
-#      - integration-tests:
-#          <<: *build-test-filter
-#          requires:
-#            - build-app
-#            - lint
-#            - check-format
+      - check-format:
+          <<: *build-test-filter
+      - build-app:
+          <<: *build-test-filter
+      - unit-tests:
+          <<: *build-test-filter
+          requires:
+            - build-app
+            - lint
+            - check-format
+      - community-unit-tests:
+          <<: *build-test-filter
+          requires:
+            - build-app
+            - lint
+            - check-format
+      - e2e-tests:
+          <<: *build-test-filter
+          requires:
+            - build-app
+            - lint
+            - check-format
+      - integration-tests:
+          <<: *build-test-filter
+          requires:
+            - build-app
+            - lint
+            - check-format
 
   publish-to-appcenter:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,25 @@ jobs:
             - app/build
       - save-cache: *save-cache-gradle
 
+  test-job:
+    <<: *build-defaults
+    resource_class: large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: *workspace
+      - restore-cache: *restore-cache-gradle
+      - run: *get-secrets
+      - run: *configure-git-user
+      - run:
+          name: Increment Version Code
+          command: ./gradlew incrementVersionCode
+      - persist_to_workspace:
+          root: .
+          paths:
+            - app/build
+      - save-cache: *save-cache-gradle
+
   publish-to-appcenter:
     <<: *build-defaults
     resource_class: medium+
@@ -221,36 +240,38 @@ workflows:
 
   build-test:
     jobs:
-      - lint:
+      - test-job:
           <<: *build-test-filter
-      - check-format:
-          <<: *build-test-filter
-      - build-app:
-          <<: *build-test-filter
-      - unit-tests:
-          <<: *build-test-filter
-          requires:
-            - build-app
-            - lint
-            - check-format
-      - community-unit-tests:
-          <<: *build-test-filter
-          requires:
-            - build-app
-            - lint
-            - check-format
-      - e2e-tests:
-          <<: *build-test-filter
-          requires:
-            - build-app
-            - lint
-            - check-format
-      - integration-tests:
-          <<: *build-test-filter
-          requires:
-            - build-app
-            - lint
-            - check-format
+#      - lint:
+#          <<: *build-test-filter
+#      - check-format:
+#          <<: *build-test-filter
+#      - build-app:
+#          <<: *build-test-filter
+#      - unit-tests:
+#          <<: *build-test-filter
+#          requires:
+#            - build-app
+#            - lint
+#            - check-format
+#      - community-unit-tests:
+#          <<: *build-test-filter
+#          requires:
+#            - build-app
+#            - lint
+#            - check-format
+#      - e2e-tests:
+#          <<: *build-test-filter
+#          requires:
+#            - build-app
+#            - lint
+#            - check-format
+#      - integration-tests:
+#          <<: *build-test-filter
+#          requires:
+#            - build-app
+#            - lint
+#            - check-format
 
   publish-to-appcenter:
     jobs:

--- a/build.gradle
+++ b/build.gradle
@@ -101,8 +101,6 @@ task incrementVersionCode {
             commandLine "git", "fetch", "${remote}"
         }
 
-        def propertiesFile = new FileOutputStream("${rootDir}/gradle.properties")
-
         exec {
             workingDir "${rootDir}"
             commandLine "git", "tag", "-a", "$versionCodeTag", "-m", "$versionCodeTag"

--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,10 @@ task incrementVersionCode {
         def versionCode = project.property("versionCode")
         def versionCodeTag = "v0.$versionCode"
         def newVersionCode = (versionCode as Integer) + 1
+        // Create build directory if not created
+        if (!buildDir.exists()) {
+            buildDir.mkdir()
+        }
 
         exec {
             workingDir "${rootDir}"
@@ -109,7 +113,12 @@ task incrementVersionCode {
             commandLine "sed",
                     "s@versionCode=.*@versionCode=${newVersionCode}@",
                     "gradle.properties"
-            standardOutput propertiesFile
+            standardOutput new FileOutputStream("${buildDir}/gradle.properties")
+        }
+
+        exec {
+            workingDir "${rootDir}"
+            commandLine "mv", "${buildDir}/gradle.properties", "gradle.properties"
         }
 
         exec {

--- a/build.gradle
+++ b/build.gradle
@@ -101,8 +101,6 @@ task incrementVersionCode {
             commandLine "git", "fetch", "${remote}"
         }
 
-        def propertiesFile = new FileOutputStream("${rootDir}/gradle.properties")
-
         exec {
             workingDir "${rootDir}"
             commandLine "git", "tag", "-a", "$versionCodeTag", "-m", "$versionCodeTag"
@@ -113,7 +111,12 @@ task incrementVersionCode {
             commandLine "sed",
                     "s@versionCode=.*@versionCode=${newVersionCode}@",
                     "gradle.properties"
-            standardOutput propertiesFile
+            standardOutput new FileOutputStream("${buildDir}/gradle.properties")
+        }
+
+        exec {
+            workingDir "${rootDir}"
+            commandLine "mv", "${buildDir}/gradle.properties", "gradle.properties"
         }
 
         exec {

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,9 @@ task incrementVersionCode {
 
         exec {
             workingDir "${rootDir}"
-            commandLine "echo", "versionCode=${newVersionCode}"
+            commandLine "sed",
+                    "s@versionCode=.*@versionCode=${newVersionCode}@",
+                    "gradle.properties"
             standardOutput propertiesFile
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,8 @@ task incrementVersionCode {
             commandLine "git", "fetch", "${remote}"
         }
 
+        def propertiesFile = new FileOutputStream("${rootDir}/gradle.properties")
+
         exec {
             workingDir "${rootDir}"
             commandLine "git", "tag", "-a", "$versionCodeTag", "-m", "$versionCodeTag"
@@ -111,12 +113,7 @@ task incrementVersionCode {
             commandLine "sed",
                     "s@versionCode=.*@versionCode=${newVersionCode}@",
                     "gradle.properties"
-            standardOutput new FileOutputStream("${buildDir}/gradle.properties")
-        }
-
-        exec {
-            workingDir "${rootDir}"
-            commandLine "mv", "${buildDir}/gradle.properties", "gradle.properties"
+            standardOutput propertiesFile
         }
 
         exec {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-versionCode=100
+versionCode=101
 android.useAndroidX=true
 android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-versionCode=100

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+versionCode=99
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+versionCode=104
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,0 @@
-versionCode=101
-android.useAndroidX=true
-android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-versionCode=99
+versionCode=100
 android.useAndroidX=true
 android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+versionCode=102
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,0 @@
-versionCode=103
-android.useAndroidX=true
-android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-versionCode=102
+versionCode=103
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
## Description

Use the `sed` command to only change the versionCode in the `gradle.properties` file so the `android.useAndroidX` and `android.enableJetifier` properties do not get overwritten.

## Validation

- Tested the gradle task in Circle CI on a separate branch

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
