### PR TITLE
Use Android Video 7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
 # Change Log
 
-## 0.108
+## 0.109 (October 15, 2021)
+
+### Dependency Upgrades
+
+* This release uses Video Android SDK 7.0.1.
+
+## 0.108 (September 17, 2021)
 
 ### Dependency Upgrades
 
 * This release uses Video Android SDK 7.0.0.
 * The minimum supported Android API level has been raised to 21.
 
-### 0.107
+### 0.107 (September 13, 2021)
 
 ### New Feature
 
@@ -24,7 +30,7 @@
 **Note:** See git history for other changes since version 0.1.0.
 
 
-## 0.1.0
+## 0.1.0 (November 8, 2019)
 
 This release marks the first iteration of the Twilio Video Collaboration App: a canonical multi-party collaboration video application built with Programmable Video. This application is intended to demonstrate the capabilities of Programmable Video and serve as a reference to developers building video apps.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,7 @@ afterEvaluate {
             debugImplementation project(':video:ktx')
             releaseImplementation project(':video:ktx')
         } else {
-            implementation "com.twilio:video-android-ktx:7.0.0"
+            implementation "com.twilio:video-android-ktx:7.0.1"
         }
     }
 }


### PR DESCRIPTION
#### Bug Fixes

- Fixed an interoperability bug between JavaScript, iOS and Android SDKs which could cause subscription events not to fire in a Peer-to-Peer or Go Room. [VIDEO-7334] [#211](https://github.com/twilio/twilio-video-ios/issues/211)

#### Known Issues

- As of 6.0.0 of the SDK, hardware video encoding doesn't publish all of the three simulcast layers when VP8 simulcast is enabled on Android.
  This affects Video Content Preferences from working properly for subscribing video participants since the feature requires all three simulcast layers to switch between.
  Our team is working on a fix for this, but the feature does work when VP8 simulcast is used to publish video from participants using the Javascript or iOS SDKs.
- Video Content Preferences might prefer larger video than needed when device orientations are mismatched. For example, if a participant in landscape mode publishes video, then the subscribing participant must also be in landscape mode in order for the correctly sized simulcast layers to be selected. The same is true for the portrait orientation.
- When the publisher is publishing video at 720p with VP8 simulcast enabled and the subscriber varies their hints between 180p, 360p, and 720p, sometimes the subscriber receives larger video than expected.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
