### PR TITLE
Use Android Video 7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.110 (November 3, 2021)
+
+### Dependency Upgrades
+
+* This release uses Video Android SDK 7.0.2.
+
 ## 0.109 (October 15, 2021)
 
 ### Dependency Upgrades

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,7 @@ afterEvaluate {
             debugImplementation project(':video:ktx')
             releaseImplementation project(':video:ktx')
         } else {
-            implementation "com.twilio:video-android-ktx:7.0.1"
+            implementation "com.twilio:video-android-ktx:7.0.2"
         }
     }
 }


### PR DESCRIPTION
#### New Features

- The SDK now supports audio only rooms and added two error codes, ROOM_AUDIO_ONLY_FLAG_NOT_SUPPORTED_EXCEPTION (53124) & TRACK_TRACK_KIND_NOT_SUPPORTED_EXCEPTION (53125).

#### Enhancements

- Improved reconnection time after network connectivity disruptions.

#### Known Issues

- As of 6.0.0 of the SDK, hardware video encoding doesn't publish all of the three simulcast layers when VP8 simulcast is enabled on Android.
  This affects Video Content Preferences from working properly for subscribing video participants since the feature requires all three simulcast layers to switch between.
  Our team is working on a fix for this, but the feature does work when VP8 simulcast is used to publish video from participants using the Javascript or iOS SDKs.
- Video Content Preferences might prefer larger video than needed when device orientations are mismatched. For example, if a participant in landscape mode publishes video, then the subscribing participant must also be in landscape mode in order for the correctly sized simulcast layers to be selected. The same is true for the portrait orientation.
- When the publisher is publishing video at 720p with VP8 simulcast enabled and the subscriber varies their hints between 180p, 360p, and 720p, sometimes the subscriber receives larger video than expected.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
