### PR TITLE
Changes to show permissions dialog and delay the start of audioswitch…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * Updated to properly support Android 12
 * Delayed starting of AudioSwitch till after user has granted necessary permissions
-* Updated to use AudioSwitch 1.1.4
+* Updated to use AudioSwitch 1.1.3
 
 ## 0.109 (October 15, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 * This release uses Video Android SDK 7.0.2.
 
+## 0.110 (November 2, 2021)
+
+* Updated to properly support Android 12
+* Delayed starting of AudioSwitch till after user has granted necessary permissions
+* Updated to use AudioSwitch 1.1.4
+
 ## 0.109 (October 15, 2021)
 
 ### Dependency Upgrades

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ afterEvaluate {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion '30.0.2'
 
     buildFeatures {
@@ -60,7 +60,7 @@ android {
         applicationId "com.twilio.video.app"
 
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         versionName "0.1.0"
         versionCode versionCodeProperty
@@ -147,7 +147,7 @@ dependencies {
     def retrofitVersion = '2.9.0'
     def espressoVersion = '3.3.0'
     def espresso = "androidx.test.espresso:espresso-core:$espressoVersion"
-    def androidXTest = '1.3.0'
+    def androidXTest = '1.4.1-alpha03'
     def testCore = "androidx.test:core:$androidXTest"
     def junitExtensions = 'androidx.test.ext:junit-ktx:1.1.1'
     def lifecycleVersion = '2.3.1'
@@ -185,7 +185,7 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"
     implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0'
-    implementation 'com.twilio:audioswitch:1.1.2'
+    implementation 'com.twilio:audioswitch:1.1.3'
     implementation "org.uniflow-kt:uniflow-android:$uniflowVersion"
 
     /*
@@ -194,7 +194,7 @@ dependencies {
      */
     compileOnly 'com.android.databinding:viewbinding:4.1.3'
 
-    internalImplementation "com.microsoft.appcenter:appcenter-distribute:3.3.1"
+    internalImplementation "com.microsoft.appcenter:appcenter-distribute:4.3.1"
 
     kapt daggerAndroidProcessor
     kapt daggerCompiler
@@ -223,7 +223,7 @@ dependencies {
     androidTestImplementation "androidx.test:runner:$androidXTest"
     androidTestImplementation "androidx.test:rules:$androidXTest"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$espressoVersion"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'com.squareup.rx.idler:rx2-idler:0.9.1'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,10 +23,10 @@
         <activity
             android:name=".ui.splash.SplashActivity"
             android:theme="@style/AppTheme.SplashScreen"
-            android:configChanges="orientation|screenSize">
+            android:configChanges="orientation|screenSize"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
-
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
             <intent-filter android:autoVerify="true"

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
@@ -19,7 +19,6 @@ import android.Manifest
 import android.animation.ObjectAnimator
 import android.animation.PropertyValuesHolder
 import android.animation.ValueAnimator
-import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.app.Activity
 import android.app.AlertDialog

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
@@ -19,6 +19,7 @@ import android.Manifest
 import android.animation.ObjectAnimator
 import android.animation.PropertyValuesHolder
 import android.animation.ValueAnimator
+import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.app.Activity
 import android.app.AlertDialog
@@ -330,12 +331,20 @@ class RoomActivity : AppCompatActivity() {
     }
 
     private fun requestPermissions() {
+        // nested if statements used to keep lint happy and avoid needing a @SuppressLint decoration
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            requestPermissions(arrayOf(
-                    Manifest.permission.RECORD_AUDIO,
-                    Manifest.permission.CAMERA
-            ),
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                requestPermissions(
+                    arrayOf(Manifest.permission.RECORD_AUDIO,
+                        Manifest.permission.CAMERA,
+                        Manifest.permission.BLUETOOTH_CONNECT),
                     PERMISSIONS_REQUEST_CODE)
+            } else {
+                requestPermissions(
+                    arrayOf(Manifest.permission.RECORD_AUDIO,
+                        Manifest.permission.CAMERA),
+                    PERMISSIONS_REQUEST_CODE)
+            }
         }
     }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomNotification.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomNotification.kt
@@ -19,7 +19,10 @@ class RoomNotification(private val context: Context) {
             get() =
                 Intent(context, RoomActivity::class.java).let { notificationIntent ->
                     notificationIntent.flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-                    PendingIntent.getActivity(context, 0, notificationIntent, 0)
+                    // Android 12/S requires a flag to be set and FLAG_IMMUTBALE isn't available
+                    // before Android M (23)
+                    var flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
+                    PendingIntent.getActivity(context, 0, notificationIntent, flags)
                 }
 
     init {

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomViewModel.kt
@@ -88,14 +88,6 @@ class RoomViewModel @Inject constructor(
     internal var roomManagerJob: Job? = null
 
     init {
-        audioSwitch.start { audioDevices, selectedDevice ->
-            updateState { currentState ->
-                currentState.copy(
-                        selectedDevice = selectedDevice,
-                        availableAudioDevices = audioDevices
-                )
-            }
-        }
         subscribeToRoomEvents()
     }
 
@@ -163,6 +155,16 @@ class RoomViewModel @Inject constructor(
             currentState.copy(isCameraEnabled = isCameraEnabled, isMicEnabled = isMicEnabled)
         }
         if (isCameraEnabled && isMicEnabled) {
+            // start audio switch, it will silently error if it has already been started
+            audioSwitch.start { audioDevices, selectedDevice ->
+                updateState { currentState ->
+                    currentState.copy(
+                        selectedDevice = selectedDevice,
+                        availableAudioDevices = audioDevices
+                    )
+                }
+            }
+            // resume everything else
             roomManager.onResume()
         } else {
             if (!permissionCheckRetry) {

--- a/build.gradle
+++ b/build.gradle
@@ -178,9 +178,6 @@ allprojects {
         }
         maven {
             url = uri("https://oss.sonatype.org/content/repositories/snapshots")
-            mavenContent {
-                snapshotsOnly()
-            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -176,5 +176,11 @@ allprojects {
         maven {
             url 'https://jitpack.io'
         }
+        maven {
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+            mavenContent {
+                snapshotsOnly()
+            }
+        }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,1 @@
 include ':app'
-

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,2 @@
 include ':app'
 
-includeBuild("/Users/afalls/code/audioswitch") {
-    dependencySubstitution {
-        substitute(module("com.twilio:audioswitch")).with(project(":audioswitch"))
-    }
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,7 @@
 include ':app'
+
+includeBuild("/Users/afalls/code/audioswitch") {
+    dependencySubstitution {
+        substitute(module("com.twilio:audioswitch")).with(project(":audioswitch"))
+    }
+}


### PR DESCRIPTION
## Description

Updated Ahoy application to work with Android 12 and to use the latest version of AudioSwitch.

## Breakdown

 * Modified to request user for Bluetooth permissions on Android 12 and newer devices.
 * Delayed the starting of AudioSwitch until the user has been granted/denied permission requests
 * Made other minor fixes to support Android 12 (Intents needed some additional flags)
 * Upgraded dependencies that prevented application from working on Android 12 devices

## Validation

- Ran application with the following setups..
     1) Android 12 device, permissions accepted, tested that bluetooth worked
     2) Android 12 device, permissions denied, tested that app didn't crash
     3) Android 12 device, no bluetooth connected
     4) Pre-Android 12 device with bluetooth device connected 
     5) Pre-Android 12 device with bluetooth not connected.

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [*] I acknowledge that all my contributions will be made under the project's license.
