### PR TITLE
VIDEO-7914: Various FTL test run fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.17.3
+version: 2.1
 
 aliases:
   # Workspace
@@ -16,31 +16,6 @@ aliases:
     paths:
       - ~/.gradle/caches
       - ~/.gradle/wrapper
-  - &get-secrets
-    name: Setup secrets
-    command: |
-      # Internal debug google services
-      mkdir -p app/src/internal/debug || true
-      echo $GOOGLE_SERVICES_INTERNAL_DEBUG_JSON | base64 -di > app/src/internal/debug/google-services.json
-      # Internal release google services
-      mkdir -p app/src/internal/release || true
-      echo $GOOGLE_SERVICES_INTERNAL_RELEASE_JSON | base64 -di > app/src/internal/release/google-services.json
-      # Gradle Properties
-      mkdir -p ~/.gradle
-      mkdir -p $PWD/secrets
-      echo $ANDROID_KEYSTORE | base64 -di > $PWD/secrets/android.keystore
-      echo "androidKeystore=$PWD/secrets/android.keystore" >> ~/.gradle/gradle.properties
-      echo "androidKeystorePassword=$VIDEO_APP_KEYSTORE_PASSWORD" >> ~/.gradle/gradle.properties
-      echo "androidReleaseKeyAlias=$VIDEO_APP_RELEASE_KEY_ALIAS" >> ~/.gradle/gradle.properties
-      echo "androidReleaseKeyPassword=$VIDEO_APP_RELEASE_KEY_PASSWORD" >> ~/.gradle/gradle.properties
-      echo "org.gradle.jvmargs=-Xmx4608m" >> ~/.gradle/gradle.properties
-      echo "APPCENTER_APP_KEY=$APPCENTER_APP_KEY" >> ./local.properties
-
-  - &configure-git-user
-    name: Configure git user
-    command: |
-      git config --global user.email "twilio-sdk-build@twilio.com"
-      git config --global user.name "twilio-sdk-build"
 
   - &build-test-filter
     filters:
@@ -54,62 +29,188 @@ aliases:
         only:
           - master
 
-  # Containers
-  - &build-defaults
+executors:
+  build:
+    parameters:
+      resource-class:
+        description: "Build executor resource class"
+        default: "large"
+        type: string
     working_directory: *workspace
     docker:
       - image: circleci/android:api-28-node
     environment:
-      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
+      _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
+    resource_class: << parameters.resource-class >>
 
-  - &ui-test-defaults
+  test:
+    parameters:
+      resource-class:
+        description: "Test executor resource class"
+        default: "medium+"
+        type: string
     working_directory: *workspace
     docker:
       - image: google/cloud-sdk:latest
-    environment:
-    resource_class: medium+
+    resource_class: << parameters.resource-class >>
 
-  - &gcloud-auth
-    name: Google Cloud Auth
-    command: >
-      echo $GCP_KEY | base64 -d | gcloud auth activate-service-account --key-file=-
+commands:
+  configure_git_user:
+    description: Configure git user
+    steps:
+      - run:
+          name: Configure git user
+          command: |
+            git config --global user.email "twilio-sdk-build@twilio.com"
+            git config --global user.name "twilio-sdk-build"jobs:
+
+  gcloud_auth:
+    description: "Authenticate gcloud client"
+    steps:
+      - run:
+          name: Google Cloud Auth
+          command: echo $GCP_KEY | base64 -d | gcloud auth activate-service-account --key-file=-
+
+  install_secrets:
+    description: Extract and configure secrets required for building and publishing
+    steps:
+      - run:
+          name: Install secrets
+          command: |
+            # Internal debug google services
+            mkdir -p app/src/internal/debug || true
+            echo $GOOGLE_SERVICES_INTERNAL_DEBUG_JSON | base64 -di > app/src/internal/debug/google-services.json
+            # Internal release google services
+            mkdir -p app/src/internal/release || true
+            echo $GOOGLE_SERVICES_INTERNAL_RELEASE_JSON | base64 -di > app/src/internal/release/google-services.json
+            # Gradle Properties
+            mkdir -p ~/.gradle
+            mkdir -p $PWD/secrets
+            echo $ANDROID_KEYSTORE | base64 -di > $PWD/secrets/android.keystore
+            echo "androidKeystore=$PWD/secrets/android.keystore" >> ~/.gradle/gradle.properties
+            echo "androidKeystorePassword=$VIDEO_APP_KEYSTORE_PASSWORD" >> ~/.gradle/gradle.properties
+            echo "androidReleaseKeyAlias=$VIDEO_APP_RELEASE_KEY_ALIAS" >> ~/.gradle/gradle.properties
+            echo "androidReleaseKeyPassword=$VIDEO_APP_RELEASE_KEY_PASSWORD" >> ~/.gradle/gradle.properties
+            echo "org.gradle.jvmargs=-Xmx4608m" >> ~/.gradle/gradle.properties
+            echo "APPCENTER_APP_KEY=$APPCENTER_APP_KEY" >> ./local.properties
+
+  setup_ftl_output:
+    description: Setup environment to capture FTL output
+    steps:
+      - run:
+          name: Setup FTL Output
+          command: |
+            # Google Cloud bucket we have set up for storing FTL output
+            FTL_RESULTS_BUCKET=video-app-79418-ftl-output
+
+            # Generate a sufficiently psuedo random suffix to store test results
+            TIMESTAMP=`date -u "+%Y-%m-%d_%H:%M:%S"`
+            RAND_SUFFIX=`openssl rand -hex 12`
+            FTL_RESULTS_DIR="${TIMESTAMP}_${RAND_SUFFIX}"
+
+            # Establish local directories to transfer and persist code coverage and result files
+            JUNIT_RESULTS_DIR=video/build/outputs/test-results/junit
+            LOCAL_RESULTS_DIR=video/build/outputs/test-results/${FTL_RESULTS_DIR}
+            mkdir -p ${JUNIT_RESULTS_DIR}
+            mkdir -p ${LOCAL_RESULTS_DIR}
+
+            # Make environment available to other workflow steps
+            echo export FTL_RESULTS_BUCKET=$FTL_RESULTS_BUCKET >>$BASH_ENV
+            echo export FTL_RESULTS_DIR=$FTL_RESULTS_DIR >>$BASH_ENV
+            echo export JUNIT_RESULTS_DIR=$JUNIT_RESULTS_DIR >>$BASH_ENV
+            echo export LOCAL_RESULTS_DIR=$LOCAL_RESULTS_DIR >>$BASH_ENV
+
+  retrieve_ftl_output:
+    description: Download test results from FTL
+    steps:
+      - run:
+          name: Retrieve FTL Output
+          # NOTE: Ensure this step is also executed after after a failure:
+          when: always
+          command: |
+            echo "Copying the FTL test results to a local directory..."
+            DEVICES=($(gsutil ls gs://${FTL_RESULTS_BUCKET}/${FTL_RESULTS_DIR} | grep -e "/$" | awk -F "/" '{print $(NF-1)}'))
+            FAILED=0
+            for DEVICE in "${DEVICES[@]}"
+            do
+                echo "Fetching FTL test results for device ${DEVICE}"
+                GSUTIL_CMD="gsutil cp \
+                  gs://${FTL_RESULTS_BUCKET}/${FTL_RESULTS_DIR}/${DEVICE}/test_result_1.xml \
+                  ${JUNIT_RESULTS_DIR}/${FTL_RESULTS_DIR}-${DEVICE}.xml"
+                if ${GSUTIL_CMD}
+                then
+                    echo "Successfully retrieved FTL test results for $DEVICE"
+                else
+                    echo "Failed to retrieve FTL test results for $DEVICE"
+                    FAILED=$((FAILED + 1))
+                fi
+
+                echo "Fetching FTL artifacts for device ${DEVICE}"
+                mkdir -p ${LOCAL_RESULTS_DIR}/${DEVICE}
+                GSUTIL_CMD="gsutil -m rsync -r \
+                  gs://${FTL_RESULTS_BUCKET}/${FTL_RESULTS_DIR}/${DEVICE} \
+                  ${LOCAL_RESULTS_DIR}/${DEVICE}"
+                if ${GSUTIL_CMD}
+                then
+                    echo "Successfully retrieved FTL artifacts for $DEVICE"
+                else
+                    echo "Failed to retrieve FTL artifacts for $DEVICE"
+                    FAILED=$((FAILED + 1))
+                fi
+            done
+
+            # If retrieval was successful, delete the FTL results in the gcloud bucket
+            if (( $FAILED == 0 ))
+            then
+                echo "Deleting FTL output from the gcloud bucket"
+                GSUTIL_CMD="gsutil -m rm -r gs://${FTL_RESULTS_BUCKET}/${FTL_RESULTS_DIR}"
+                if ${GSUTIL_CMD}
+                then
+                    echo "Successfully deleted FTL output from gcloud bucket"
+                else
+                    echo "Failed to delete FTL output from gcloud bucket"
+                    FAILED=$((FAILED + 1))
+                fi
+            else
+                echo "${FAILED} retrievals failed, leaving the FTL output in the gcloud bucket: gs://${FTL_RESULTS_BUCKET}/${FTL_RESULTS_DIR}"
+            fi
+            echo "Done."
 
 jobs:
   lint:
-    <<: *build-defaults
-    resource_class: large
+    executor: build
     steps:
       - checkout
-      - restore-cache: *restore-cache-gradle
-      - run: *get-secrets
+      - restore_cache: *restore-cache-gradle
+      - install_secrets
       - run:
           name: Lint
           command: ./gradlew -q lint
       - store_artifacts:
           path: app/build/reports/lint-results.html
-          prefix: app
-      - save-cache: *save-cache-gradle
+          destination: app
+      - save_cache: *save-cache-gradle
 
   check-format:
-    <<: *build-defaults
-    resource_class: medium+
+    executor:
+      name: build
+      resource-class: medium+
     steps:
       - checkout
-      - restore-cache: *restore-cache-gradle
+      - restore_cache: *restore-cache-gradle
       - run:
           name: Spotless Check
           command: ./gradlew -q spotlessCheck
-      - save-cache: *save-cache-gradle
+      - save_cache: *save-cache-gradle
 
   build-app:
-    <<: *build-defaults
-    resource_class: large
+    executor: build
     steps:
       - checkout
       - attach_workspace:
           at: *workspace
-      - restore-cache: *restore-cache-gradle
-      - run: *get-secrets
+      - restore_cache: *restore-cache-gradle
+      - install_secrets
       - run:
           name: Store Test Credentials
           command: echo $TEST_CREDENTIALS_JSON | base64 -di > app/src/androidTest/assets/Credentials/TestCredentials.json
@@ -120,74 +221,89 @@ jobs:
           root: .
           paths:
             - app/build
-      - save-cache: *save-cache-gradle
+      - save_cache: *save-cache-gradle
 
   unit-tests:
-    <<: *build-defaults
-    resource_class: large
+    executor: build
     steps:
       - checkout
       - attach_workspace:
           at: *workspace
-      - restore-cache: *restore-cache-gradle
-      - run: *get-secrets
+      - restore_cache: *restore-cache-gradle
+      - install_secrets
       - run:
           name: Unit Tests
           command: ./gradlew app:testInternalDebugUnitTest
-      - save-cache: *save-cache-gradle
+      - save_cache: *save-cache-gradle
 
   community-unit-tests:
-    <<: *build-defaults
-    resource_class: large
+    executor: build
     steps:
       - checkout
       - attach_workspace:
           at: *workspace
-      - restore-cache: *restore-cache-gradle
-      - run: *get-secrets
+      - restore_cache: *restore-cache-gradle
+      - install_secrets
       - run:
           name: Community Unit Tests
           command: ./gradlew app:testCommunityDebugUnitTest
-      - save-cache: *save-cache-gradle
+      - save_cache: *save-cache-gradle
 
   e2e-tests:
-    <<: *ui-test-defaults
+    executor: test
     steps:
       # Setup
       - checkout
       - attach_workspace:
           at: *workspace
-      - run: *gcloud-auth
+      - gcloud_auth
+      - setup_ftl_output
       - run:
           name: E2E Tests
+          # Circle CI has a default timeout that will fail build steps if there is no output for 10 minutes.
+          no_output_timeout: 30m
           command: >
-            gcloud firebase test android run --num-flaky-test-attempts=1 --use-orchestrator --environment-variables clearPackageData=true --project video-app-79418
+            gcloud firebase test android run --num-flaky-test-attempts=1 --use-orchestrator --environment-variables clearPackageData=true --project video-app-79418 --results-bucket $FTL_RESULTS_BUCKET --results-dir ${FTL_RESULTS_DIR}
             ui-test-args.yaml:e2e-tests
+      - retrieve_ftl_output
+      - store_test_results:
+          path: video/build/outputs/test-results/junit
+      - store_artifacts:
+          path: video/build/outputs/test-results
+          destination: test-results
 
   integration-tests:
-    <<: *ui-test-defaults
+    executor: test
     steps:
       # Setup
       - checkout
       - attach_workspace:
           at: *workspace
-      - run: *gcloud-auth
+      - gcloud_auth
+      - setup_ftl_output
       - run:
           name: Integration Tests
+          # Circle CI has a default timeout that will fail build steps if there is no output for 10 minutes.
+          no_output_timeout: 30m
           command: >
-            gcloud firebase test android run --use-orchestrator --environment-variables clearPackageData=true --project video-app-79418
+            gcloud firebase test android run --use-orchestrator --environment-variables clearPackageData=true --project video-app-79418 --results-bucket $FTL_RESULTS_BUCKET --results-dir ${FTL_RESULTS_DIR}
             ui-test-args.yaml:integration-tests
+      - retrieve_ftl_output
+      - store_test_results:
+          path: video/build/outputs/test-results/junit
+      - store_artifacts:
+          path: video/build/outputs/test-results
+          destination: test-results
 
   build-release-app:
-    <<: *build-defaults
-    resource_class: large
+    executor: build
     steps:
       - checkout
       - attach_workspace:
           at: *workspace
-      - restore-cache: *restore-cache-gradle
-      - run: *get-secrets
-      - run: *configure-git-user
+      - restore_cache: *restore-cache-gradle
+      - install_secrets
+      - configure_git_user
       - run:
           name: Increment Version Code
           command: ./gradlew incrementVersionCode
@@ -198,12 +314,12 @@ jobs:
           root: .
           paths:
             - app/build
-      - save-cache: *save-cache-gradle
+      - save_cache: *save-cache-gradle
 
   publish-to-appcenter:
-    <<: *build-defaults
-    resource_class: medium+
-    name: Publish to AppCenter
+    executor:
+      name: build
+      resource-class: medium+
     steps:
       - attach_workspace:
           at: *workspace
@@ -217,8 +333,6 @@ jobs:
             appcenter distribute release -f app/build/outputs/apk/internal/release/app-internal-release.apk -g Testers --app nico-hokeyapp-dzyz/Video-App-Internal
 
 workflows:
-  version: 2
-
   build-test:
     jobs:
       - lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,21 +38,17 @@ executors:
         type: string
     working_directory: *workspace
     docker:
-      - image: circleci/android:api-28-node
+      - image: cimg/android:2021.10.2-node
     environment:
       _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
     resource_class: << parameters.resource-class >>
 
-  test:
+  ftl-test:
     parameters:
-      resource-class:
-        description: "Test executor resource class"
-        default: "medium+"
-        type: string
     working_directory: *workspace
     docker:
       - image: google/cloud-sdk:latest
-    resource_class: << parameters.resource-class >>
+    resource_class: small
 
 commands:
   configure_git_user:
@@ -250,7 +246,7 @@ jobs:
       - save_cache: *save-cache-gradle
 
   e2e-tests:
-    executor: test
+    executor: ftl-test
     steps:
       # Setup
       - checkout
@@ -273,7 +269,7 @@ jobs:
           destination: test-results
 
   integration-tests:
-    executor: test
+    executor: ftl-test
     steps:
       # Setup
       - checkout

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/BaseE2ETest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/BaseE2ETest.kt
@@ -1,9 +1,11 @@
 package com.twilio.video.app.e2eTest
 
+import android.util.Log
 import com.twilio.video.app.screen.loginWithEmail
 import com.twilio.video.app.util.allowAllPermissions
 import com.twilio.video.app.util.retrieveEmailCredentials
 import com.twilio.video.app.util.uiDevice
+import java.util.concurrent.TimeoutException
 import org.junit.Before
 
 @E2ETest
@@ -12,7 +14,12 @@ open class BaseE2ETest {
     open fun setUp() {
         loginWithEmail(retrieveEmailCredentials())
         uiDevice().run {
-            allowAllPermissions()
+            try {
+                allowAllPermissions()
+            } catch (e: TimeoutException) {
+                Log.w("VideoApiUtils", "Permissions dialog not detected")
+                // try running the test anyway
+            }
         }
     }
 }

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
@@ -419,17 +419,15 @@ class RoomActivity : AppCompatActivity() {
 
         // TODO: Remove when we use a Service to obtainTokenAndConnect to a room
         settingsMenuItem.isVisible = settingsMenuItemState
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            screenCaptureMenuItem.isVisible = screenCaptureMenuItemState
-            val screenCaptureResources = if (roomViewState.isScreenCaptureOn) {
-                R.drawable.ic_stop_screen_share_white_24dp to getString(R.string.stop_screen_share)
-            } else {
-                R.drawable.ic_screen_share_white_24dp to getString(R.string.share_screen)
-            }
-            screenCaptureMenuItem.icon = ContextCompat.getDrawable(this,
-                    screenCaptureResources.first)
-            screenCaptureMenuItem.title = screenCaptureResources.second
+        screenCaptureMenuItem.isVisible = screenCaptureMenuItemState
+        val screenCaptureResources = if (roomViewState.isScreenCaptureOn) {
+            R.drawable.ic_stop_screen_share_white_24dp to getString(R.string.stop_screen_share)
+        } else {
+            R.drawable.ic_screen_share_white_24dp to getString(R.string.share_screen)
         }
+        screenCaptureMenuItem.icon = ContextCompat.getDrawable(this,
+                screenCaptureResources.first)
+        screenCaptureMenuItem.title = screenCaptureResources.second
     }
 
     private fun setTitle(toolbarTitle: String?) {

--- a/app/src/main/java/com/twilio/video/app/util/CameraCapturerCompat.kt
+++ b/app/src/main/java/com/twilio/video/app/util/CameraCapturerCompat.kt
@@ -94,42 +94,39 @@ class CameraCapturerCompat(
                 if (isCamera2) isCameraIdSupported(context, cameraId) else true
 
         private fun isCameraIdSupported(context: Context, cameraId: String): Boolean {
-            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
-                var isMonoChromeSupported = false
-                var isPrivateImageFormatSupported = false
-                val cameraCharacteristics: CameraCharacteristics
-                cameraCharacteristics = try {
-                    cameraManager.getCameraCharacteristics(cameraId)
-                } catch (e: Exception) {
-                    Timber.e(e)
-                    return false
-                }
-                /*
-                 * This is a temporary work around for a RuntimeException that occurs on devices which contain cameras
-                 * that do not support ImageFormat.PRIVATE output formats. A long term fix is currently in development.
-                 * https://github.com/twilio/video-quickstart-android/issues/431
-                 */
-                val streamMap = cameraCharacteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
-                if (streamMap != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    isPrivateImageFormatSupported = streamMap.isOutputSupportedFor(ImageFormat.PRIVATE)
-                }
+            val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+            var isMonoChromeSupported = false
+            var isPrivateImageFormatSupported = false
+            val cameraCharacteristics: CameraCharacteristics = try {
+                cameraManager.getCameraCharacteristics(cameraId)
+            } catch (e: Exception) {
+                Timber.e(e)
+                return false
+            }
+            /*
+             * This is a temporary work around for a RuntimeException that occurs on devices which contain cameras
+             * that do not support ImageFormat.PRIVATE output formats. A long term fix is currently in development.
+             * https://github.com/twilio/video-quickstart-android/issues/431
+             */
+            val streamMap = cameraCharacteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
+            if (streamMap != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                isPrivateImageFormatSupported = streamMap.isOutputSupportedFor(ImageFormat.PRIVATE)
+            }
 
-                /*
-                 * Read the color filter arrangements of the camera to filter out the ones that support
-                 * SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_MONO or SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_NIR.
-                 * Visit this link for details on supported values - https://developer.android.com/reference/android/hardware/camera2/CameraCharacteristics#SENSOR_INFO_COLOR_FILTER_ARRANGEMENT
-                 */
-                val colorFilterArrangement = cameraCharacteristics.get(
-                        CameraCharacteristics.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && colorFilterArrangement != null) {
-                    isMonoChromeSupported = (colorFilterArrangement
-                            == CameraMetadata.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_MONO ||
-                            colorFilterArrangement
-                            == CameraMetadata.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_NIR)
-                }
-                isPrivateImageFormatSupported && !isMonoChromeSupported
-            } else true
+            /*
+             * Read the color filter arrangements of the camera to filter out the ones that support
+             * SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_MONO or SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_NIR.
+             * Visit this link for details on supported values - https://developer.android.com/reference/android/hardware/camera2/CameraCharacteristics#SENSOR_INFO_COLOR_FILTER_ARRANGEMENT
+             */
+            val colorFilterArrangement = cameraCharacteristics.get(
+                    CameraCharacteristics.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && colorFilterArrangement != null) {
+                isMonoChromeSupported = (colorFilterArrangement
+                        == CameraMetadata.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_MONO ||
+                        colorFilterArrangement
+                        == CameraMetadata.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_NIR)
+            }
+            return isPrivateImageFormatSupported && !isMonoChromeSupported
         }
 
         private fun isAtLeastOneCameraAvailable(frontCameraId: String?, backCameraId: String?) =

--- a/ui-test-args.yaml
+++ b/ui-test-args.yaml
@@ -4,8 +4,8 @@ e2e-tests:
   app: app/build/outputs/apk/internal/debug/app-internal-debug.apk
   test: app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk
   device:
-    - {model: lucye, version: 24}
-    - {model: flame, version: 29}
+    - {model: hammerhead, version: 23}
+    - {model: redfin, version: 30}
   test-targets:
     - "annotation com.twilio.video.app.e2eTest.E2ETest"
 
@@ -15,10 +15,10 @@ integration-tests:
   app: app/build/outputs/apk/internal/debug/app-internal-debug.apk
   test: app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk
   device:
-    - {model: athene, version: 23}
-    - {model: lucye, version: 24}
-    - {model: sawfish, version: 26}
-    - {model: albus, version: 26}
-    - {model: flame, version: 29}
+    - {model: hammerhead, version: 23}
+    - {model: griffin, version: 24}
+    - {model: HWCOR, version: 27}
+    - {model: pettyl, version: 27}
+    - {model: redfin, version: 30}
   test-targets:
     - "annotation com.twilio.video.app.integrationTest.IntegrationTest"


### PR DESCRIPTION
## Description

This PR introduces a number of fixes and enhancements related to the FTL test automation and Circle CI pipelines:

- Replace/update deprecated FTL test devices
- Publish test output from FTL runs to Circle CI
- Refactor and update Circle CI config

## Breakdown

- remove/replace obsolete device/API combinations
- remove pre-LOLLIPOP checks in code, since minSdk is now 21
- refactor circleci config to use commands and executors
- add build steps to publish FTL test output to a gcloud bucket
- add build steps to retrieve FTL test output from gcloud bucket and publish to Circle CI as test results and artifacts
- use small executor for FTL tests
- replace deprecated circlci/android docker image with new cimg variant

## Validation

- Circle CI runs show FTL test results and publish test output as artifacts.

## Additional Notes

E2E tests are still failing, that work is tracked in VIDEO-7718 and will be addressed separately.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
