### PR TITLE
Consume Video Android SDK 7.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Change Log
 
-## 0.110 (November 3, 2021)
+## 0.114 (December 6, 2021)
+
+### Dependency Upgrades
+
+* This release uses Video Android SDK 7.0.3.
+
+## 0.113 (November 3, 2021)
 
 ### Dependency Upgrades
 
 * This release uses Video Android SDK 7.0.2.
 
-## 0.110 (November 2, 2021)
+## 0.111 (November 2, 2021)
 
 * Updated to properly support Android 12
 * Delayed starting of AudioSwitch till after user has granted necessary permissions

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,7 @@ afterEvaluate {
             debugImplementation project(':video:ktx')
             releaseImplementation project(':video:ktx')
         } else {
-            implementation "com.twilio:video-android-ktx:7.0.2"
+            implementation "com.twilio:video-android-ktx:7.0.3"
         }
     }
 }


### PR DESCRIPTION
* Programmable Video Android SDK 7.0.3 [[Maven Central]](https://search.maven.org/artifact/com.twilio/video-android/7.0.3/aar), [[docs]](https://twilio.github.io/twilio-video-android/docs/7.0.3/)
* Programmable Video Android KTX SDK 7.0.3 [[Maven Central]](https://search.maven.org/artifact/com.twilio/video-android-ktx/7.0.3/aar), [[docs]](https://twilio.github.io/twilio-video-android/docs/ktx/7.0.3/)

#### API Changes

- Added error code definition `PARTICIPANT_SESSION_LENGTH_EXCEEDED_EXCEPTION`.

#### Bug Fixes

- Fixed a bug where if an exception occurs when connecting to a Room, the Room instance could leak and setting a custom audio device could fail.
- Fixed a bug where media could incorrectly be detected as not flowing after the network connectivity changes.

#### Known Issues

- As of 6.0.0 of the SDK, hardware video encoding doesn't publish all of the three simulcast layers when VP8 simulcast is enabled on Android.
  This affects Video Content Preferences from working properly for subscribing video participants since the feature requires all three simulcast layers to switch between.
  Our team is working on a fix for this, but the feature does work when VP8 simulcast is used to publish video from participants using the Javascript or iOS SDKs.
- Video Content Preferences might prefer larger video than needed when device orientations are mismatched. For example, if a participant in landscape mode publishes video, then the subscribing participant must also be in landscape mode in order for the correctly sized simulcast layers to be selected. The same is true for the portrait orientation.
- When the publisher is publishing video at 720p with VP8 simulcast enabled and the subscriber varies their hints between 180p, 360p, and 720p, sometimes the subscriber receives larger video than expected.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
