### PR TITLE
fix e2e failing test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 0.117 (January 6, 2022)
+
+### Bug Fixes
+
+* Updated e2e test cases such that successful execution is possible
+
+### Dependency Upgrades
+
+* Updated Espresso to 3.5.0-alpha03
+* Updated junit/junit-ktx to 1.1.4-alpha03
+
 ## 0.116 (January 4, 2022)
 
 ### Dependency Upgrades

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,6 +85,7 @@ android {
 
     testOptions {
         execution 'ANDROIDX_TEST_ORCHESTRATOR'
+        animationsDisabled = true
         unitTests {
             includeAndroidResources = true
         }
@@ -146,11 +147,12 @@ dependencies {
     def daggerCompiler = "com.google.dagger:dagger-compiler:$daggerVersion"
     def hiltVersion = '2.38.1'
     def retrofitVersion = '2.9.0'
-    def espressoVersion = '3.3.0'
+    def espressoVersion = '3.5.0-alpha03'
     def espresso = "androidx.test.espresso:espresso-core:$espressoVersion"
     def androidXTest = '1.4.1-alpha03'
+    def andoridXJunit = '1.1.4-alpha03'
     def testCore = "androidx.test:core:$androidXTest"
-    def junitExtensions = 'androidx.test.ext:junit-ktx:1.1.1'
+    def junitExtensions = "androidx.test.ext:junit-ktx:$andoridXJunit"
     def lifecycleVersion = '2.3.1'
     def coroutinesAndroidVersion = '1.4.3'
     def fragmentVersion = '1.3.2'
@@ -226,7 +228,7 @@ dependencies {
     androidTestImplementation "androidx.test:runner:$androidXTest"
     androidTestImplementation "androidx.test:rules:$androidXTest"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$espressoVersion"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation "androidx.test.ext:junit:$andoridXJunit"
     androidTestImplementation 'com.squareup.rx.idler:rx2-idler:0.9.1'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     androidTestUtil "androidx.test:orchestrator:$androidXTest"

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/BaseE2ETest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/BaseE2ETest.kt
@@ -1,6 +1,10 @@
 package com.twilio.video.app.e2eTest
 
 import android.util.Log
+import android.app.Activity
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
+import androidx.test.runner.lifecycle.Stage.RESUMED
 import com.twilio.video.app.screen.loginWithEmail
 import com.twilio.video.app.util.allowAllPermissions
 import com.twilio.video.app.util.retrieveEmailCredentials
@@ -12,6 +16,9 @@ import org.junit.Before
 open class BaseE2ETest {
     @Before
     open fun setUp() {
+        // wait for google/firebase auth activity to overlay
+        waitUntilActivityVisible<com.firebase.ui.auth.ui.idp.AuthMethodPickerActivity>(5000)
+        // start test
         loginWithEmail(retrieveEmailCredentials())
         uiDevice().run {
             try {
@@ -19,6 +26,33 @@ open class BaseE2ETest {
             } catch (e: TimeoutException) {
                 Log.w("VideoApiUtils", "Permissions dialog not detected")
                 // try running the test anyway
+            }
+        }
+    }
+
+    open fun getActivityInstance(): Activity? {
+        var currentActivity : Activity ?= null
+        getInstrumentation().runOnMainSync {
+            val resumedActivities: Collection<*> =
+                ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(RESUMED)
+            if (resumedActivities.iterator().hasNext()) {
+                currentActivity = resumedActivities.iterator().next() as Activity
+            }
+        }
+        return currentActivity
+    }
+
+    inline fun <reified T : Activity> isVisible() : Boolean {
+        return T::class.java.name == getActivityInstance()!!::class.java.name
+    }
+
+    inline fun <reified T : Activity> waitUntilActivityVisible(timeout : Long) {
+        val startTime = System.currentTimeMillis()
+        while (!isVisible<T>()) {
+            Thread.sleep(100)
+            if (System.currentTimeMillis() - startTime >= timeout) {
+                throw AssertionError(
+                    "Activity ${T::class.java.simpleName} not visible after $timeout milliseconds")
             }
         }
     }

--- a/app/src/androidTest/java/com/twilio/video/app/e2eTest/BaseE2ETest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/e2eTest/BaseE2ETest.kt
@@ -1,7 +1,7 @@
 package com.twilio.video.app.e2eTest
 
-import android.util.Log
 import android.app.Activity
+import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
 import androidx.test.runner.lifecycle.Stage.RESUMED
@@ -31,7 +31,7 @@ open class BaseE2ETest {
     }
 
     open fun getActivityInstance(): Activity? {
-        var currentActivity : Activity ?= null
+        var currentActivity: Activity ? = null
         getInstrumentation().runOnMainSync {
             val resumedActivities: Collection<*> =
                 ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(RESUMED)
@@ -42,11 +42,11 @@ open class BaseE2ETest {
         return currentActivity
     }
 
-    inline fun <reified T : Activity> isVisible() : Boolean {
+    inline fun <reified T : Activity> isVisible(): Boolean {
         return T::class.java.name == getActivityInstance()!!::class.java.name
     }
 
-    inline fun <reified T : Activity> waitUntilActivityVisible(timeout : Long) {
+    inline fun <reified T : Activity> waitUntilActivityVisible(timeout: Long) {
         val startTime = System.currentTimeMillis()
         while (!isVisible<T>()) {
             Thread.sleep(100)

--- a/app/src/androidTest/java/com/twilio/video/app/espresso/DrawableMatchers.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/espresso/DrawableMatchers.kt
@@ -2,12 +2,12 @@ package com.twilio.video.app.espresso
 
 import android.content.Context
 import android.content.res.Resources
-import android.graphics.drawable.Drawable
-import android.view.View
-import android.widget.ImageView
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.view.View
+import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import androidx.appcompat.view.menu.ActionMenuItemView
 import org.hamcrest.Description
@@ -50,7 +50,7 @@ class DrawableMatcher(
             Bitmap.Config.ARGB_8888
         )
         val canvas = Canvas(bitmap)
-        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight())
+        drawable.setBounds(0, 0, canvas.width, canvas.height)
         drawable.draw(canvas)
         return bitmap
     }

--- a/app/src/androidTest/java/com/twilio/video/app/espresso/DrawableMatchers.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/espresso/DrawableMatchers.kt
@@ -5,6 +5,9 @@ import android.content.res.Resources
 import android.graphics.drawable.Drawable
 import android.view.View
 import android.widget.ImageView
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
 import androidx.annotation.DrawableRes
 import androidx.appcompat.view.menu.ActionMenuItemView
 import org.hamcrest.Description
@@ -25,11 +28,30 @@ class DrawableMatcher(
 
         val resources: Resources = target.context.resources
         val expectedDrawable: Drawable? = resources.getDrawable(expectedId, targetContext.theme)
-        return expectedDrawable?.constantState?.let { it == drawable.constantState } ?: false
+        return if (expectedDrawable != null) {
+            makeBitmap(drawable)?.sameAs(makeBitmap(expectedDrawable)) ?: false
+        } else {
+            false
+        }
     }
 
     override fun describeTo(description: Description) {
         description.appendText("with drawable from resource id: $expectedId")
         targetContext.resources.getResourceEntryName(expectedId)?.let { description.appendText("[$it]") }
+    }
+
+    private fun makeBitmap(drawable: Drawable): Bitmap? {
+        if (drawable is BitmapDrawable) {
+            return drawable.bitmap
+        }
+        val bitmap = Bitmap.createBitmap(
+            drawable.intrinsicWidth,
+            drawable.intrinsicHeight,
+            Bitmap.Config.ARGB_8888
+        )
+        val canvas = Canvas(bitmap)
+        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight())
+        drawable.draw(canvas)
+        return bitmap
     }
 }

--- a/app/src/androidTest/java/com/twilio/video/app/screen/LoginScreen.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/screen/LoginScreen.kt
@@ -16,19 +16,19 @@ import org.hamcrest.Matchers
 
 // TODO Move to common module as part of https://issues.corp.twilio.com/browse/AHOYAPPS-197
 
-class DisableAutofillAction: ViewAction {
+class DisableAutofillAction : ViewAction {
     override fun getConstraints(): Matcher<View>? {
         return Matchers.any(View::class.java)
     }
 
     override fun getDescription(): String {
-        return "Marking view not important for autofill";
+        return "Marking view not important for autofill"
     }
 
     override fun perform(uiController: UiController?, view: View?) {
         // Required to disable autofill suggestions during tests on API 26+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            view?.importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO;
+            view?.importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO
         }
     }
 }

--- a/app/src/androidTest/java/com/twilio/video/app/screen/LoginScreen.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/screen/LoginScreen.kt
@@ -1,14 +1,37 @@
 package com.twilio.video.app.screen
 
+import android.os.Build
+import android.view.View
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import com.twilio.video.app.EmailCredentials
 import com.twilio.video.app.R
 import com.twilio.video.app.util.retryEspressoAction
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers
 
 // TODO Move to common module as part of https://issues.corp.twilio.com/browse/AHOYAPPS-197
+
+class DisableAutofillAction: ViewAction {
+    override fun getConstraints(): Matcher<View>? {
+        return Matchers.any(View::class.java)
+    }
+
+    override fun getDescription(): String {
+        return "Marking view not important for autofill";
+    }
+
+    override fun perform(uiController: UiController?, view: View?) {
+        // Required to disable autofill suggestions during tests on API 26+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            view?.importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO;
+        }
+    }
+}
 
 fun loginWithEmail(emailCredentials: EmailCredentials) {
     loginWithEmail(emailCredentials.email, emailCredentials.password)
@@ -16,8 +39,13 @@ fun loginWithEmail(emailCredentials: EmailCredentials) {
 
 private fun loginWithEmail(email: String, password: String) {
     onView(withId(R.id.email_button)).perform(click())
-    onView(withId(R.id.email)).perform(typeText(email))
+    onView(withId(R.id.email)).perform(
+        DisableAutofillAction(),
+        typeText(email))
     onView(withId(R.id.button_next)).perform(click())
-    retryEspressoAction { onView(withId(R.id.password)).perform(typeText(password)) }
+    retryEspressoAction { onView(withId(R.id.password)).perform(
+        DisableAutofillAction(),
+        typeText(password))
+    }
     onView(withId(R.id.button_done)).perform(click())
 }

--- a/app/src/androidTest/java/com/twilio/video/app/util/UiAutomatorExtensions.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/util/UiAutomatorExtensions.kt
@@ -9,11 +9,11 @@ import java.util.concurrent.TimeoutException
 fun uiDevice(): UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
 fun UiDevice.allowAllPermissions() {
-    clickThroughDialogs("Allow|ALLOW")
+    clickThroughDialogs("Allow|ALLOW|While using the app")
 }
 
 fun UiDevice.denyAllPermissions() {
-    clickThroughDialogs("Deny|DENY")
+    clickThroughDialogs("Deny|DENY|Don\\p{Punct}t allow")
 }
 
 private fun UiDevice.clickThroughDialogs(text: String) {


### PR DESCRIPTION
## Description

Fixed e2e test cases so that they are able to pass again on modern devices.

## Breakdown

- Updated search UI string for enable/disable of permissions
- Updated matcher to do a bitmap compare of drawables because as of Android 21, using ConstantState as a proxy for equality is no longer supported (https://stackoverflow.com/questions/9125229/comparing-two-drawables-in-android)
- Updated test cases to wait for Firebase AuthUI to run its login activity before attempting to inject username/password  for test cases.

## Validation

- Ran AndroidTest test cases on multiple devices

## Additional Notes

This does not fix all the flakiness, but is a large step in the right direction.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
