### PR TITLE
Remove iSAC codec references, webrtc 112

### DIFF
--- a/app/src/main/java/com/twilio/video/app/sdk/ConnectOptionsFactory.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/ConnectOptionsFactory.kt
@@ -10,7 +10,6 @@ import com.twilio.video.ConnectOptions
 import com.twilio.video.EncodingParameters
 import com.twilio.video.G722Codec
 import com.twilio.video.H264Codec
-import com.twilio.video.IsacCodec
 import com.twilio.video.NetworkQualityConfiguration
 import com.twilio.video.NetworkQualityVerbosity
 import com.twilio.video.OpusCodec
@@ -244,7 +243,6 @@ class ConnectOptionsFactory(
         )?.let { audioCodecName ->
 
             when (audioCodecName) {
-                IsacCodec.NAME -> IsacCodec()
                 PcmaCodec.NAME -> PcmaCodec()
                 PcmuCodec.NAME -> PcmuCodec()
                 G722Codec.NAME -> G722Codec()

--- a/app/src/main/java/com/twilio/video/app/ui/settings/AdvancedSettingsFragment.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/settings/AdvancedSettingsFragment.kt
@@ -8,7 +8,6 @@ import androidx.preference.Preference
 import com.twilio.video.AudioCodec
 import com.twilio.video.G722Codec
 import com.twilio.video.H264Codec
-import com.twilio.video.IsacCodec
 import com.twilio.video.OpusCodec
 import com.twilio.video.PcmaCodec
 import com.twilio.video.PcmuCodec
@@ -30,7 +29,7 @@ class AdvancedSettingsFragment : BaseSettingsFragment() {
 
     private var identityPreference: EditTextPreference? = null
     private val videoCodecNames = arrayOf(Vp8Codec.NAME, H264Codec.NAME, Vp9Codec.NAME)
-    private val audioCodecNames = arrayOf(IsacCodec.NAME, OpusCodec.NAME, PcmaCodec.NAME, PcmuCodec.NAME, G722Codec.NAME)
+    private val audioCodecNames = arrayOf(OpusCodec.NAME, PcmaCodec.NAME, PcmuCodec.NAME, G722Codec.NAME)
 
     override fun onStart() {
         super.onStart()


### PR DESCRIPTION
## Description
Remove iSAC codec references

## Breakdown

- Remove iSAC codec references

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
