### PR TITLE
[VBLOCKS-3546] Publish internal release to Firebase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ aliases:
       - ~/.gradle/caches
       - ~/.gradle/wrapper
 
-  - &publish-to-appcenter-filter
+  - &publish-to-firebase-filter
     filters:
       branches:
         only:
@@ -64,7 +64,9 @@ commands:
     steps:
       - run:
           name: Google Cloud Auth
-          command: echo $GCP_KEY | base64 -d | gcloud auth activate-service-account --key-file=-
+          command: |
+            echo $GCP_KEY | base64 -di > app/gcp-key.json
+            gcloud auth activate-service-account --key-file=app/gcp-key.json
 
   install_secrets:
     description: Extract and configure secrets required for building and publishing
@@ -74,10 +76,10 @@ commands:
           command: |
             # Internal debug google services
             mkdir -p app/src/internal/debug || true
-            echo $GOOGLE_SERVICES_INTERNAL_DEBUG_JSON | base64 -di > app/src/internal/debug/google-services.json
+            echo $GOOGLE_SERVICES_INTERNAL_JSON | base64 -di > app/src/internal/debug/google-services.json
             # Internal release google services
             mkdir -p app/src/internal/release || true
-            echo $GOOGLE_SERVICES_INTERNAL_RELEASE_JSON | base64 -di > app/src/internal/release/google-services.json
+            echo $GOOGLE_SERVICES_INTERNAL_JSON | base64 -di > app/src/internal/release/google-services.json
             # Gradle Properties
             mkdir -p ~/.gradle
             mkdir -p $PWD/secrets
@@ -87,7 +89,6 @@ commands:
             echo "androidReleaseKeyAlias=$VIDEO_APP_RELEASE_KEY_ALIAS" >> ~/.gradle/gradle.properties
             echo "androidReleaseKeyPassword=$VIDEO_APP_RELEASE_KEY_PASSWORD" >> ~/.gradle/gradle.properties
             echo "org.gradle.jvmargs=-Xmx4608m" >> ~/.gradle/gradle.properties
-            echo "APPCENTER_APP_KEY=$APPCENTER_APP_KEY" >> ./local.properties
 
   setup_ftl_output:
     description: Setup environment to capture FTL output
@@ -311,7 +312,7 @@ jobs:
             - app/build
       - save_cache: *save-cache-gradle
 
-  publish-to-appcenter:
+  publish-to-firebase:
     executor:
       name: build
       resource-class: medium+
@@ -319,13 +320,9 @@ jobs:
       - attach_workspace:
           at: *workspace
       - run:
-          # TODO Ticket to improve build time here https://issues.corp.twilio.com/browse/AHOYAPPS-67
-          # TODO Ticket to add latest changelog update https://issues.corp.twilio.com/browse/AHOYAPPS-94
-          command: |
-            sudo npm install webpack
-            echo no | sudo npm install -g appcenter-cli
-            appcenter login --token $APPCENTER_API_TOKEN
-            appcenter distribute release -f app/build/outputs/apk/internal/release/app-internal-release.apk -g Testers --app nico-hokeyapp-dzyz/Video-App-Internal
+          command: >
+            GOOGLE_APPLICATION_CREDENTIALS=app/gcp-key.json 
+            ./gradlew -q app:assembleInternalRelease app:appDistributionUploadInternalRelease
 
 workflows:
   build-test:
@@ -368,13 +365,13 @@ workflows:
             - lint
             - check-format
 
-  publish-to-appcenter:
+  publish-to-firebase:
     when:
       not: << pipeline.parameters.biweekly_run >>
     jobs:
       - build-release-app:
-          <<: *publish-to-appcenter-filter
-      - publish-to-appcenter:
-          <<: *publish-to-appcenter-filter
+          <<: *publish-to-firebase-filter
+      - publish-to-firebase:
+          <<: *publish-to-firebase-filter
           requires:
             - build-release-app

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,9 +1,12 @@
-apply plugin: 'com.android.application'
-apply plugin: 'com.google.gms.google-services'
-apply plugin: 'com.google.firebase.crashlytics'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
-apply plugin: 'dagger.hilt.android.plugin'
+plugins {
+    id 'com.android.application'
+    id 'com.google.gms.google-services'
+    id 'com.google.firebase.crashlytics'
+    id 'kotlin-android'
+    id 'kotlin-kapt'
+    id 'dagger.hilt.android.plugin'
+    id 'com.google.firebase.appdistribution'
+}
 
 def versionCodeProperty = project.property('versionCode') as Integer
 def includeSdkFromSourceProperty = 'includeSdkFromSource'
@@ -110,8 +113,6 @@ android {
             signingConfig signingConfigs.release
         }
         debug {
-            applicationIdSuffix ".debug"
-            versionNameSuffix "-debug"
             signingConfig signingConfigs.debug
         }
     }
@@ -123,8 +124,13 @@ android {
             dimension "environment"
             applicationId "com.twilio.video.app.internal"
             buildConfigField 'String', 'ENVIRONMENT_DEFAULT', '"production"'
-            buildConfigField 'String', 'APPCENTER_APP_KEY',
-                    "\"${getLocalProperty("APPCENTER_APP_KEY")}\""
+
+            firebaseAppDistribution {
+                appId = "1:285008367772:android:4da97cc5e2ebc0ea"
+                artifactType = "APK"
+                releaseNotes = "Ahoy App (Internal), look at CHANGELOG.md for more info."
+                groups = "QE"
+            }
         }
 
         community {
@@ -201,8 +207,6 @@ dependencies {
      * to com.android.ViewBinding.
      */
     compileOnly 'com.android.databinding:viewbinding:4.1.3'
-
-    internalImplementation "com.microsoft.appcenter:appcenter-distribute:4.3.1"
 
     kapt daggerAndroidProcessor
     kapt daggerCompiler

--- a/app/src/community/java/com/twilio/video/app/AppCenterWrapper.kt
+++ b/app/src/community/java/com/twilio/video/app/AppCenterWrapper.kt
@@ -1,5 +1,0 @@
-package com.twilio.video.app
-
-import android.app.Application
-
-fun startAppcenter(application: Application) {}

--- a/app/src/internal/java/com/twilio/video/app/AppCenterWrapper.kt
+++ b/app/src/internal/java/com/twilio/video/app/AppCenterWrapper.kt
@@ -1,9 +1,0 @@
-package com.twilio.video.app
-
-import android.app.Application
-import com.microsoft.appcenter.AppCenter
-import com.microsoft.appcenter.distribute.Distribute
-
-fun startAppcenter(application: Application) {
-    AppCenter.start(application, BuildConfig.APPCENTER_APP_KEY, Distribute::class.java)
-}

--- a/app/src/main/java/com/twilio/video/app/VideoApplication.kt
+++ b/app/src/main/java/com/twilio/video/app/VideoApplication.kt
@@ -37,7 +37,5 @@ class VideoApplication : Application() {
         super.onCreate()
 
         Timber.plant(tree)
-
-        startAppcenter(this)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -42,10 +42,11 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.3.1'
-        classpath "com.google.gms:google-services:4.3.10"
+        classpath "com.google.gms:google-services:4.4.2"
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.1'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.2'
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.40.1'
+        classpath 'com.google.firebase:firebase-appdistribution-gradle:5.0.0'
     }
 }
 


### PR DESCRIPTION
## Description

Instead of publishing to AppCenter, publish to Firebase

## Breakdown

- Removed AppCenter integration points
- Added support for publishing to Firebase

## Validation

- Ran locally and published

## Additional Notes

None

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
