### PR TITLE
Hide Firebase App ID

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ commands:
             echo "androidKeystorePassword=$VIDEO_APP_KEYSTORE_PASSWORD" >> ~/.gradle/gradle.properties
             echo "androidReleaseKeyAlias=$VIDEO_APP_RELEASE_KEY_ALIAS" >> ~/.gradle/gradle.properties
             echo "androidReleaseKeyPassword=$VIDEO_APP_RELEASE_KEY_PASSWORD" >> ~/.gradle/gradle.properties
+            echo "firebaseAppId=$FIREBASE_APP_ID" >> ~/.gradle/gradle.properties
             echo "org.gradle.jvmargs=-Xmx4608m" >> ~/.gradle/gradle.properties
 
   setup_ftl_output:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,7 +126,7 @@ android {
             buildConfigField 'String', 'ENVIRONMENT_DEFAULT', '"production"'
 
             firebaseAppDistribution {
-                appId = "1:285008367772:android:4da97cc5e2ebc0ea"
+                appId = firebaseAppId
                 artifactType = "APK"
                 releaseNotes = "Ahoy App (Internal), look at CHANGELOG.md for more info."
                 groups = "QE"

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@ buildscript {
             project.property('androidReleaseKeyAlias') : 'fakealias')
     ext.releaseKeyPassword = (project.hasProperty('androidReleaseKeyPassword') ?
             project.property('androidReleaseKeyPassword') : 'fakepassword')
+    ext.firebaseAppId = (project.hasProperty('firebaseAppId') ?
+            project.property('firebaseAppId') : 'fakeappid')
 
     ext.getPropertyValue =  { propertyKey ->
         def property  = System.getenv(propertyKey)


### PR DESCRIPTION
## Description

Because this codebase is public, lets hide the Firebase App ID

## Breakdown

- Hide the firebase app ID in an environment variable

## Validation

- Published

## Additional Notes

None

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
