### PR TITLE
Changes in preparation of WebRTC-124 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## 0.156 (Nov 12, 2024)
+
+### Dependency Upgrades
+
+* Updated twilio-android-env to 1.1.1 to support 16k pages
+
+### Feature Changes
+
+* In preparation for the WebRTC-124 upgrade, the following necessary changes were made
+   * removed support for globally setting audio channel effects as the necessary class WebRtcAudioUtils is removed from WebRTC-124.
+   * removed support for globally setting the usage of SLES audio device as the necessary class WebRtcAudioManager is removed from WebRTC-124.
+
+
 ## 0.155 (Oct 23, 2024)
 
 ### Dependency Upgrades

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -179,7 +179,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesAndroidVersion"
     // TODO Remove as part of https://issues.corp.twilio.com/browse/AHOYAPPS-445
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$coroutinesAndroidVersion"
-    implementation 'com.twilio:twilio-android-env:1.1.0@aar'
+    implementation 'com.twilio:twilio-android-env:1.1.1@aar'
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
     implementation 'com.google.android.material:material:1.3.0'
     implementation "androidx.preference:preference-ktx:1.1.1"

--- a/app/src/main/java/com/twilio/video/app/sdk/ConnectOptionsFactory.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/ConnectOptionsFactory.kt
@@ -28,8 +28,6 @@ import com.twilio.video.app.util.EnvUtil
 import com.twilio.video.app.util.get
 import com.twilio.video.ktx.createBandwidthProfileOptions
 import com.twilio.video.ktx.createConnectOptions
-import tvi.webrtc.voiceengine.WebRtcAudioManager
-import tvi.webrtc.voiceengine.WebRtcAudioUtils
 
 class ConnectOptionsFactory(
     private val context: Context,

--- a/app/src/main/java/com/twilio/video/app/sdk/ConnectOptionsFactory.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/ConnectOptionsFactory.kt
@@ -120,14 +120,18 @@ class ConnectOptionsFactory(
             Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL,
             Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL_DEFAULT,
         )
-        val openSLESUsage = sharedPreferences.getBoolean(
-            Preferences.AUDIO_OPEN_SLES_USAGE,
-            Preferences.AUDIO_OPEN_SLES_USAGE_DEFAULT,
-        )
-        WebRtcAudioUtils.setWebRtcBasedAcousticEchoCanceler(!acousticEchoCanceler)
-        WebRtcAudioUtils.setWebRtcBasedNoiseSuppressor(!noiseSuppressor)
-        WebRtcAudioUtils.setWebRtcBasedAutomaticGainControl(!automaticGainControl)
-        WebRtcAudioManager.setBlacklistDeviceForOpenSLESUsage(!openSLESUsage)
+        // Removed due WebRTC-124 removing the WebRtcAudioUtils & WebRtcAudioManager classes
+        // Audio effects shall be added on a per-audio track basis. VBLOCKS-3744
+        //
+        // val openSLESUsage = sharedPreferences.getBoolean(
+        //     Preferences.AUDIO_OPEN_SLES_USAGE,
+        //     Preferences.AUDIO_OPEN_SLES_USAGE_DEFAULT,
+        // )
+
+        // WebRtcAudioUtils.setWebRtcBasedAcousticEchoCanceler(!acousticEchoCanceler)
+        // WebRtcAudioUtils.setWebRtcBasedNoiseSuppressor(!noiseSuppressor)
+        // WebRtcAudioUtils.setWebRtcBasedAutomaticGainControl(!automaticGainControl)
+        // WebRtcAudioManager.setBlacklistDeviceForOpenSLESUsage(!openSLESUsage)
 
         val isNetworkQualityEnabled = sharedPreferences.get(
             Preferences.ENABLE_NETWORK_QUALITY_LEVEL,


### PR DESCRIPTION
## Description

Removed code that is no longer supported as of WebRTC-124.

## Breakdown

- Commented out code that is no longer supported in WebRTC-124

## Validation

- Built & Ran

## Additional Notes

Removed functionality will be added back via a different means at a different time. [VBLOCKS-3744]

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
