### PR TITLE
[VBLOCKS-3844] fixed permission errors when running on newer devices (API34+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.157 (Dec 6, 2024)
+
+### Bug Fixes
+
+* Fixed bug regarding missing permissions when using android 34+ devices
+
 ## 0.156 (Nov 12, 2024)
 
 ### Dependency Upgrades

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -171,6 +171,7 @@ dependencies {
     def coroutinesAndroidVersion = '1.4.3'
     def fragmentVersion = '1.3.2'
     def uniflowVersion = '1.0.5'
+    def androidEnv = '1.1.1'
 
     implementation platform('com.google.firebase:firebase-bom:25.9.0')
 
@@ -179,7 +180,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesAndroidVersion"
     // TODO Remove as part of https://issues.corp.twilio.com/browse/AHOYAPPS-445
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$coroutinesAndroidVersion"
-    implementation 'com.twilio:twilio-android-env:1.1.1@aar'
+    implementation "com.twilio:twilio-android-env:$androidEnv@aar"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
     implementation 'com.google.android.material:material:1.3.0'
     implementation "androidx.preference:preference-ktx:1.1.1"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,8 +10,11 @@
 
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
 
     <application
         android:name=".VideoApplication"
@@ -53,7 +56,8 @@
             android:parentActivityName=".ui.room.RoomActivity"
             android:theme="@style/AppTheme.Settings" />
         <service
-            android:foregroundServiceType="mediaProjection"
-            android:name=".ui.room.VideoService"/>
+            android:foregroundServiceType="mediaProjection|camera|microphone"
+            android:name=".ui.room.VideoService"
+            android:exported="false" />
     </application>
 </manifest>

--- a/app/src/main/java/com/twilio/video/app/sdk/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/RoomManager.kt
@@ -25,6 +25,8 @@ import com.twilio.video.app.ui.room.RoomEvent.RecordingStopped
 import com.twilio.video.app.ui.room.RoomEvent.RemoteParticipantEvent.RemoteParticipantConnected
 import com.twilio.video.app.ui.room.RoomEvent.RemoteParticipantEvent.RemoteParticipantDisconnected
 import com.twilio.video.app.ui.room.RoomEvent.StatsUpdate
+import com.twilio.video.app.ui.room.VideoService.Companion.disableScreenShare
+import com.twilio.video.app.ui.room.VideoService.Companion.enableScreenShare
 import com.twilio.video.app.ui.room.VideoService.Companion.startService
 import com.twilio.video.app.ui.room.VideoService.Companion.stopService
 import kotlinx.coroutines.CoroutineDispatcher
@@ -108,10 +110,12 @@ class RoomManager(
     }
 
     fun startScreenCapture(captureResultCode: Int, captureIntent: Intent) {
+        enableScreenShare(room!!.name)
         localParticipantManager.startScreenCapture(captureResultCode, captureIntent)
     }
 
     fun stopScreenCapture() {
+        disableScreenShare(room!!.name)
         localParticipantManager.stopScreenCapture()
     }
 

--- a/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/room/RoomActivity.kt
@@ -244,7 +244,7 @@ class RoomActivity : AppCompatActivity() {
 
     public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode == MEDIA_PROJECTION_REQUEST_CODE) {
+        if (requestCode == MEDIA_PROJECTION_REQUEST_CODE &&  data != null) {
             if (resultCode != RESULT_OK) {
                 Snackbar.make(
                     binding.room.primaryVideo,
@@ -338,7 +338,17 @@ class RoomActivity : AppCompatActivity() {
     private fun requestPermissions() {
         // nested if statements used to keep lint happy and avoid needing a @SuppressLint decoration
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                requestPermissions(
+                    arrayOf(
+                        Manifest.permission.RECORD_AUDIO,
+                        Manifest.permission.CAMERA,
+                        Manifest.permission.BLUETOOTH_CONNECT,
+                        Manifest.permission.POST_NOTIFICATIONS
+                    ),
+                    PERMISSIONS_REQUEST_CODE,
+                )
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 requestPermissions(
                     arrayOf(
                         Manifest.permission.RECORD_AUDIO,


### PR DESCRIPTION
## Description

Fixed crashes due to permission errors when running on newer devices (API 34+)

## Breakdown

- Added necessary permissions and user requests for those permissions
- Modified video service to 'foreground' with necessary permissions


## Validation

- Ran app on two devices and was able to both screen share and view each other

## Additional Notes

None

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
