### PR TITLE
VBLOCKS-3744: audio options upon track construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.160 (Jan 9, 2025)
+
+### Feature Changes
+
+* Audio track options are now set upon audio track construction.
+
 ## 0.159 (Dec 10, 2024)
 
 ### Bug Fixes

--- a/app/src/androidTest/java/com/twilio/video/app/integrationTest/PreferenceIntegrationTest.kt
+++ b/app/src/androidTest/java/com/twilio/video/app/integrationTest/PreferenceIntegrationTest.kt
@@ -82,15 +82,10 @@ class PreferenceIntegrationTest : BaseIntegrationTest() {
             Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL,
             !Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL_DEFAULT,
         )
-        val openSLESUsage = sharedPreferences.getBoolean(
-            Preferences.AUDIO_OPEN_SLES_USAGE,
-            !Preferences.AUDIO_OPEN_SLES_USAGE_DEFAULT,
-        )
 
         assertThat(acousticEchoCanceler, equalTo(Preferences.AUDIO_ACOUSTIC_ECHO_CANCELER_DEFAULT))
         assertThat(noiseSuppressor, equalTo(Preferences.AUDIO_ACOUSTIC_NOISE_SUPRESSOR_DEFAULT))
         assertThat(automaticGainControl, equalTo(Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL_DEFAULT))
-        assertThat(openSLESUsage, equalTo(Preferences.AUDIO_OPEN_SLES_USAGE_DEFAULT))
     }
 
     @Test

--- a/app/src/main/java/com/twilio/video/app/data/Preferences.kt
+++ b/app/src/main/java/com/twilio/video/app/data/Preferences.kt
@@ -90,8 +90,6 @@ object Preferences {
     const val AUDIO_ACOUSTIC_NOISE_SUPRESSOR_DEFAULT = true
     const val AUDIO_AUTOMATIC_GAIN_CONTROL = "pref_audio_automatic_gain_control"
     const val AUDIO_AUTOMATIC_GAIN_CONTROL_DEFAULT = true
-    const val AUDIO_OPEN_SLES_USAGE = "pref_audio_open_sles_usage"
-    const val AUDIO_OPEN_SLES_USAGE_DEFAULT = false
     const val VIDEO_ENCODING_MODE = "pref_video_encoding_mode"
     const val VIDEO_ENCODING_MODE_DEFAULT = true
 }

--- a/app/src/main/java/com/twilio/video/app/sdk/LocalParticipantManager.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/LocalParticipantManager.kt
@@ -27,7 +27,6 @@ import com.twilio.video.app.ui.room.RoomEvent.LocalParticipantEvent.VideoTrackUp
 import com.twilio.video.app.util.CameraCapturerCompat
 import com.twilio.video.app.util.get
 import com.twilio.video.ktx.AudioOptionsBuilder
-import com.twilio.video.ktx.createAudioOptions
 import com.twilio.video.ktx.createLocalAudioTrack
 import com.twilio.video.ktx.createLocalVideoTrack
 import timber.log.Timber
@@ -160,19 +159,25 @@ class LocalParticipantManager(
 
     private fun setupLocalAudioTrack() {
         if (localAudioTrack == null && !isAudioMuted) {
-            var audioOptions: AudioOptionsBuilder =  {
+            var audioOptions: AudioOptionsBuilder = {
                 echoCancellation(
                     sharedPreferences.getBoolean(
                         Preferences.AUDIO_ACOUSTIC_ECHO_CANCELER,
-                        Preferences.AUDIO_ACOUSTIC_ECHO_CANCELER_DEFAULT))
+                        Preferences.AUDIO_ACOUSTIC_ECHO_CANCELER_DEFAULT,
+                    ),
+                )
                 noiseSuppression(
                     sharedPreferences.getBoolean(
                         Preferences.AUDIO_ACOUSTIC_NOISE_SUPRESSOR,
-                        Preferences.AUDIO_ACOUSTIC_NOISE_SUPRESSOR_DEFAULT))
+                        Preferences.AUDIO_ACOUSTIC_NOISE_SUPRESSOR_DEFAULT,
+                    ),
+                )
                 autoGainControl(
                     sharedPreferences.getBoolean(
                         Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL,
-                        Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL_DEFAULT))
+                        Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL_DEFAULT,
+                    ),
+                )
             }
             localAudioTrack = createLocalAudioTrack(context, true, MICROPHONE_TRACK_NAME, audioOptions)
             localAudioTrack?.let { publishAudioTrack(it) }

--- a/app/src/main/java/com/twilio/video/app/sdk/LocalParticipantManager.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/LocalParticipantManager.kt
@@ -166,7 +166,7 @@ class LocalParticipantManager(
                         Preferences.AUDIO_ACOUSTIC_ECHO_CANCELER,
                         Preferences.AUDIO_ACOUSTIC_ECHO_CANCELER_DEFAULT))
                 noiseSuppression(
-                    sharedPreferences.getBoolean(d
+                    sharedPreferences.getBoolean(
                         Preferences.AUDIO_ACOUSTIC_NOISE_SUPRESSOR,
                         Preferences.AUDIO_ACOUSTIC_NOISE_SUPRESSOR_DEFAULT))
                 autoGainControl(

--- a/app/src/main/java/com/twilio/video/app/sdk/LocalParticipantManager.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/LocalParticipantManager.kt
@@ -11,6 +11,7 @@ import com.twilio.video.ScreenCapturer
 import com.twilio.video.TrackPriority
 import com.twilio.video.VideoFormat
 import com.twilio.video.app.R
+import com.twilio.video.app.data.Preferences
 import com.twilio.video.app.data.Preferences.VIDEO_CAPTURE_RESOLUTION
 import com.twilio.video.app.data.Preferences.VIDEO_CAPTURE_RESOLUTION_DEFAULT
 import com.twilio.video.app.data.Preferences.VIDEO_DIMENSIONS
@@ -25,6 +26,8 @@ import com.twilio.video.app.ui.room.RoomEvent.LocalParticipantEvent.VideoEnabled
 import com.twilio.video.app.ui.room.RoomEvent.LocalParticipantEvent.VideoTrackUpdated
 import com.twilio.video.app.util.CameraCapturerCompat
 import com.twilio.video.app.util.get
+import com.twilio.video.ktx.AudioOptionsBuilder
+import com.twilio.video.ktx.createAudioOptions
 import com.twilio.video.ktx.createLocalAudioTrack
 import com.twilio.video.ktx.createLocalVideoTrack
 import timber.log.Timber
@@ -157,7 +160,21 @@ class LocalParticipantManager(
 
     private fun setupLocalAudioTrack() {
         if (localAudioTrack == null && !isAudioMuted) {
-            localAudioTrack = createLocalAudioTrack(context, true, MICROPHONE_TRACK_NAME)
+            var audioOptions: AudioOptionsBuilder =  {
+                echoCancellation(
+                    sharedPreferences.getBoolean(
+                        Preferences.AUDIO_ACOUSTIC_ECHO_CANCELER,
+                        Preferences.AUDIO_ACOUSTIC_ECHO_CANCELER_DEFAULT))
+                noiseSuppression(
+                    sharedPreferences.getBoolean(d
+                        Preferences.AUDIO_ACOUSTIC_NOISE_SUPRESSOR,
+                        Preferences.AUDIO_ACOUSTIC_NOISE_SUPRESSOR_DEFAULT))
+                autoGainControl(
+                    sharedPreferences.getBoolean(
+                        Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL,
+                        Preferences.AUDIO_AUTOMATIC_GAIN_CONTROL_DEFAULT))
+            }
+            localAudioTrack = createLocalAudioTrack(context, true, MICROPHONE_TRACK_NAME, audioOptions)
             localAudioTrack?.let { publishAudioTrack(it) }
                 ?: Timber.e(RuntimeException(), "Failed to create local audio track")
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,7 +129,7 @@
     <string name="resume_video">Resume video</string>
     <string name="share_screen">Share screen</string>
     <string name="select_audio_device">Select audio device</string>
-    <string name="stop_screen_share">Stop screen share</string>
+    <string name="stop_screen_share">Stop screen share</string>f
     <string name="screen_capture_permission_not_granted">Screen capture permission not granted</string>
     <string name="join">Join</string>
     <string name="room">Room</string>
@@ -169,5 +169,4 @@
     <string name="settings_screen_audio_acoustic_echo_canceler">Hardware Acoustic Echo Canceler</string>
     <string name="settings_screen_audio_noise_supressor">Hardware Noise Supressor</string>
     <string name="settings_screen_audio_automatic_gain_control">Hardware Automatic Gain Control</string>
-    <string name="settings_screen_audio_open_sles_usage">Open SLES Usage</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,7 +129,7 @@
     <string name="resume_video">Resume video</string>
     <string name="share_screen">Share screen</string>
     <string name="select_audio_device">Select audio device</string>
-    <string name="stop_screen_share">Stop screen share</string>f
+    <string name="stop_screen_share">Stop screen share</string>
     <string name="screen_capture_permission_not_granted">Screen capture permission not granted</string>
     <string name="join">Join</string>
     <string name="room">Room</string>

--- a/app/src/main/res/xml/audio_preferences.xml
+++ b/app/src/main/res/xml/audio_preferences.xml
@@ -20,10 +20,5 @@
         android:title="@string/settings_screen_audio_automatic_gain_control"
         android:defaultValue="true"
         app:iconSpaceReserved="false"/>
-
-    <CheckBoxPreference
-        android:key="pref_audio_open_sles_usage"
-        android:title="@string/settings_screen_audio_open_sles_usage"
-        android:defaultValue="false"
-        app:iconSpaceReserved="false"/>
+    
 </PreferenceScreen>


### PR DESCRIPTION
## Description

Instead of the audio options (Gain Control, echo cancelation, etc) being set by a webrtc singleton which was removed in WebRTC-124, its now being set as an audio option upon track construction.

## Breakdown

- Now when the audio track is created, the audio options are set
- Removed OpenSLES option as it no longer applies to WebRTC-124

## Validation

- Ran app and tested audio options

## Additional Notes

None

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
