### PR TITLE
VBLOCKS-3919: gcloud login failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.161 (Jan 11, 2024)
+
+### Bug Fixes
+
+* Fixed bug with internal releases where users could not login using their gCloud credentials
+
 ## 0.160 (Jan 9, 2025)
 
 ### Feature Changes

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -2,6 +2,7 @@
 -dontwarn tvi.webrtc.**
 -keep class com.twilio.video.** { *; }
 -keep class com.twilio.common.** { *; }
+-keep class com.google.android.gms.internal.** { *; }
 -keepattributes InnerClasses
 
 # Facebook Conceal proguard config

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -2,8 +2,10 @@
 -dontwarn tvi.webrtc.**
 -keep class com.twilio.video.** { *; }
 -keep class com.twilio.common.** { *; }
--keep class com.google.android.gms.internal.** { *; }
 -keepattributes InnerClasses
+
+# https://github.com/firebase/firebase-android-sdk/issues/4900#issuecomment-1520001376
+-keep class com.google.android.gms.internal.** { *; }
 
 # Facebook Conceal proguard config
 -keep class com.facebook.crypto.** { *; }


### PR DESCRIPTION
## Description

Fixed issue with unable to login with google account/gcloud for internal builds

## Breakdown

- Added updated RSA app signing keys to firebase (no code change)
- Prevented Progaurd from obfuscating firebase libraries (from bug/ticket in firebase github, https://github.com/firebase/firebase-android-sdk/issues/4900#issuecomment-15200013)


## Validation

- Ran both debug and release builds, signed with correct keys and was able to login

## Additional Notes
None

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
