### PR TITLE
[VBLOCKS-4001] Updated prograud rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
-## 0.161 (Jan 11, 2024)
+## 0.162 (Feb 4, 2025)
+
+### Bug Fixes
+
+* Fixed obfuscation issue causing the internal edition to fail to retrieve a token.
+
+## 0.161 (Jan 11, 2025)
 
 ### Bug Fixes
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -11,3 +11,12 @@
 -keep class com.facebook.crypto.** { *; }
 -keep class com.facebook.jni.** { *; }
 -keepclassmembers class com.facebook.cipher.jni.** { *; }
+
+# Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
+ -keep,allowobfuscation,allowshrinking interface retrofit2.Call
+ -keep,allowobfuscation,allowshrinking class retrofit2.Response
+
+ # With R8 full mode generic signatures are stripped for classes that are not
+ # kept. Suspend functions are wrapped in continuations where the type argument
+ # is used.
+ -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation

--- a/app/src/main/java/com/twilio/video/app/data/api/dto/AuthServiceRequestDTO.kt
+++ b/app/src/main/java/com/twilio/video/app/data/api/dto/AuthServiceRequestDTO.kt
@@ -1,8 +1,10 @@
 package com.twilio.video.app.data.api
 
+import com.google.gson.annotations.SerializedName
+
 data class AuthServiceRequestDTO(
-    val passcode: String? = null,
-    val user_identity: String? = null,
-    val room_name: String? = null,
-    val create_room: Boolean = false,
+    @SerializedName("passcode") val passcode: String? = null,
+    @SerializedName("user_identity") val user_identity: String? = null,
+    @SerializedName("room_name") val room_name: String? = null,
+    @SerializedName("create_room") val create_room: Boolean = false,
 )


### PR DESCRIPTION
## Description

Updated proguard rules so that retrofit does not fail to retrieve room tokens in release builds.

## Breakdown

- Updated proguard rules
- Added annotations so gson preserves member names

## Validation

-Ran release version

## Additional Notes

None

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
