### PR TITLE
[VIDEO-14649] Remove 16 kbps audio bitrate cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.176 (Apr 22, 2026)
+
+### Bug Fixes
+
+* Changed default max audio bitrate from 16 kbps to 0 (uncapped). The 16 kbps cap prevented Opus FEC from functioning effectively under packet loss.
+
 ## 0.175 (Apr 20, 2026)
 
 ### Dependency Upgrades

--- a/app/src/main/java/com/twilio/video/app/data/Preferences.kt
+++ b/app/src/main/java/com/twilio/video/app/data/Preferences.kt
@@ -71,7 +71,7 @@ object Preferences {
     const val AUDIO_CODEC = "pref_audio_codecs"
     const val AUDIO_CODEC_DEFAULT = OpusCodec.NAME
     const val MAX_AUDIO_BITRATE = "pref_max_audio_bitrate"
-    const val MAX_AUDIO_BITRATE_DEFAULT = 16
+    const val MAX_AUDIO_BITRATE_DEFAULT = 0
     const val MAX_VIDEO_BITRATE = "pref_max_video_bitrate"
     const val MAX_VIDEO_BITRATE_DEFAULT = 0
     const val RECORD_PARTICIPANTS_ON_CONNECT = "pref_record_participants_on_connect"


### PR DESCRIPTION

## Description

Change MAX_AUDIO_BITRATE_DEFAULT from 16 to 0 (WebRTC default) so Opus FEC can function effectively under packet loss.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
