### PR TITLE
VBLOCKS-6835: Fixed login issues with internal flavor of Ahoy app

### DIFF
--- a/app/src/internal/java/com/twilio/video/app/auth/AuthModule.java
+++ b/app/src/internal/java/com/twilio/video/app/auth/AuthModule.java
@@ -37,17 +37,15 @@ public class AuthModule {
     Authenticator providesAuthenticator(FirebaseWrapper firebaseWrapper, Application application) {
         Context context = application.getApplicationContext();
         List<AuthenticationProvider> authProviders = new ArrayList<>();
-        String acceptedDomain = "twilio.com";
         GoogleSignInOptions googleSignInOptions =
                 new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
                         .requestIdToken(context.getString(R.string.default_web_client_id))
                         .requestEmail()
-                        .setHostedDomain(acceptedDomain)
                         .build();
 
         authProviders.add(
                 GoogleAuthProvider.Companion.newInstance(
-                        context, googleSignInOptions, acceptedDomain));
+                        context, googleSignInOptions, "twilio.com", "gmail.com"));
         authProviders.add(new EmailAuthProvider(firebaseWrapper));
         return new FirebaseAuthenticator(firebaseWrapper, authProviders);
     }

--- a/app/src/main/java/com/twilio/video/app/auth/GoogleAuthProvider.kt
+++ b/app/src/main/java/com/twilio/video/app/auth/GoogleAuthProvider.kt
@@ -88,7 +88,9 @@ class GoogleAuthProvider @JvmOverloads internal constructor(
             onError(observable)
             return
         }
-        if (acceptedDomains.isNotEmpty() && acceptedDomains.none { email.endsWith("@$it") }) {
+        val emailDomain = email.substringAfterLast('@', "").trim().lowercase()
+        val normalizedAcceptedDomains = acceptedDomains.map { it.trim().removePrefix("@").lowercase() }
+        if (normalizedAcceptedDomains.isNotEmpty() && emailDomain !in normalizedAcceptedDomains) {
             onError(observable)
             return
         }

--- a/app/src/main/java/com/twilio/video/app/auth/GoogleAuthProvider.kt
+++ b/app/src/main/java/com/twilio/video/app/auth/GoogleAuthProvider.kt
@@ -24,7 +24,7 @@ class GoogleAuthProvider @JvmOverloads internal constructor(
     googleSignInWrapper: GoogleSignInWrapper,
     googleSignInOptionsWrapper: GoogleSignInOptionsWrapper,
     private val googleAuthProviderWrapper: GoogleAuthProviderWrapper,
-    private val acceptedDomain: String? = null,
+    private val acceptedDomains: List<String> = emptyList(),
     private val disposables: CompositeDisposable = CompositeDisposable(),
 ) : AuthenticationProvider {
 
@@ -32,7 +32,7 @@ class GoogleAuthProvider @JvmOverloads internal constructor(
         fun newInstance(
             context: Context,
             googleSignInOptions: GoogleSignInOptions,
-            acceptedDomain: String? = null,
+            vararg acceptedDomains: String,
         ): AuthenticationProvider =
             GoogleAuthProvider(
                 FirebaseWrapper(),
@@ -41,7 +41,7 @@ class GoogleAuthProvider @JvmOverloads internal constructor(
                 GoogleSignInWrapper(),
                 GoogleSignInOptionsWrapper(googleSignInOptions),
                 GoogleAuthProviderWrapper(),
-                acceptedDomain,
+                acceptedDomains.toList(),
             )
     }
 
@@ -88,11 +88,9 @@ class GoogleAuthProvider @JvmOverloads internal constructor(
             onError(observable)
             return
         }
-        acceptedDomain?.let {
-            if (!email.endsWith(it)) {
-                onError(observable)
-                return
-            }
+        if (acceptedDomains.isNotEmpty() && acceptedDomains.none { email.endsWith("@$it") }) {
+            onError(observable)
+            return
         }
         if (idToken.isNullOrBlank()) {
             onError(observable)

--- a/app/src/main/java/com/twilio/video/app/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/login/LoginActivity.kt
@@ -20,6 +20,7 @@ import android.app.Activity
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
 import com.firebase.ui.auth.AuthUI
@@ -36,6 +37,8 @@ private const val RC_SIGN_IN = 20
 
 @AndroidEntryPoint
 class LoginActivity : AppCompatActivity() {
+
+    private val allowedDomains = listOf("twilio.com", "gmail.com")
 
     private lateinit var authUI: FirebaseAuth
 
@@ -54,12 +57,25 @@ class LoginActivity : AppCompatActivity() {
         if (requestCode == RC_SIGN_IN) {
             if (resultCode == Activity.RESULT_OK) {
                 authUI.currentUser?.let { user ->
-                    saveIdentity(user)
-                    startLobbyActivity()
+                    if (isAllowedDomain(user.email)) {
+                        saveIdentity(user)
+                        startLobbyActivity()
+                    } else {
+                        AuthUI.getInstance().signOut(this)
+                        Toast.makeText(this, R.string.login_unauthorized_domain, Toast.LENGTH_LONG).show()
+                        navigateToFirebaseUIAuth()
+                        return
+                    }
                 }
             }
             finish()
         }
+    }
+
+    private fun isAllowedDomain(email: String?): Boolean {
+        if (email.isNullOrBlank()) return false
+        val domain = email.substringAfterLast('@').lowercase()
+        return domain in allowedDomains
     }
 
     private fun navigateToFirebaseUIAuth() {

--- a/app/src/main/java/com/twilio/video/app/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/twilio/video/app/ui/login/LoginActivity.kt
@@ -63,10 +63,8 @@ class LoginActivity : AppCompatActivity() {
     }
 
     private fun navigateToFirebaseUIAuth() {
-        val acceptedDomain = "twilio.com"
         val signInOptions = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
             .requestEmail()
-            .setHostedDomain(acceptedDomain)
             .build()
         val providers = arrayListOf(
             AuthUI.IdpConfig.EmailBuilder().setAllowNewAccounts(false).build(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,4 +174,5 @@
     <string name="settings_screen_audio_acoustic_echo_canceler">Hardware Acoustic Echo Canceler</string>
     <string name="settings_screen_audio_noise_supressor">Hardware Noise Supressor</string>
     <string name="settings_screen_audio_automatic_gain_control">Hardware Automatic Gain Control</string>
+    <string name="login_unauthorized_domain">Sign-in is restricted to authorized accounts only.</string>
 </resources>

--- a/app/src/test/java/com/twilio/video/app/auth/GoogleAuthProviderTest.kt
+++ b/app/src/test/java/com/twilio/video/app/auth/GoogleAuthProviderTest.kt
@@ -113,4 +113,23 @@ class GoogleAuthProviderTest : BaseUnitTest() {
         assertThat(testObservable.errorCount(), equalTo(1))
         verify(disposables).clear()
     }
+
+    @Test
+    fun `loginWithAccount should reject email with domain that is a suffix match but not exact`() {
+        whenever(googleSignInAccount.email).thenReturn("user@notwilio.com")
+
+        val googleAuthenticator = GoogleAuthProvider(
+            mock(),
+            context,
+            googleAuthWrapper,
+            googleSignInWrapper,
+            googleSignInOptionsWrapper,
+            mock(),
+            listOf("twilio.com"),
+            disposables,
+        )
+        val testObservable = googleAuthenticator.login(Observable.just(LoginEvent.GoogleLoginEvent(intent))).test()
+        assertThat(testObservable.errorCount(), equalTo(1))
+        verify(disposables).clear()
+    }
 }

--- a/app/src/test/java/com/twilio/video/app/auth/GoogleAuthProviderTest.kt
+++ b/app/src/test/java/com/twilio/video/app/auth/GoogleAuthProviderTest.kt
@@ -69,7 +69,7 @@ class GoogleAuthProviderTest : BaseUnitTest() {
             googleSignInWrapper,
             googleSignInOptionsWrapper,
             googleAuthProviderWrapper,
-            "test.com",
+            listOf("test.com"),
             disposables,
         )
         val testObservable = googleAuthenticator.login(Observable.just(LoginEvent.GoogleLoginEvent(intent))).test()
@@ -106,7 +106,7 @@ class GoogleAuthProviderTest : BaseUnitTest() {
             googleSignInWrapper,
             googleSignInOptionsWrapper,
             mock(),
-            "test.com",
+            listOf("test.com"),
             disposables,
         )
         val testObservable = googleAuthenticator.login(Observable.just(LoginEvent.GoogleLoginEvent(intent))).test()


### PR DESCRIPTION
## Description

Due to okta security changes, we now have to log in using the service account `twiliotestdevice@gmail.com` This account is not under the Twilio domain (to avoid Okta requirement on a ubi key and biometrics). When using the internal version of the Ahoy app (Only available to Twilions and QE), it would fail due to the test service account not being in the Twilio domain. This fixes that.

If you never deleted your Ahoy app, and just reinstalled new versions from android studio, you will not run into this issue. 

## Breakdown

- Modified the ahoy internal edition to allow accounts from both "@twilio.com" and "@gmail.com".


## Validation

- Ran locally on device

## Additional Notes

None

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
