### PR TITLE
VBLOCKS-5934: Fix logout functionality

### DIFF
--- a/app/src/community/java/com/twilio/video/app/auth/CommunityAuthenticator.kt
+++ b/app/src/community/java/com/twilio/video/app/auth/CommunityAuthenticator.kt
@@ -68,6 +68,6 @@ class CommunityAuthenticator constructor(
 
     override fun logout() {
         sharedPreferences.edit { remove(DISPLAY_NAME) }
-        sharedPreferences.edit { remove(PASSCODE) }
+        securePreferences.removeSecureString(PASSCODE)
     }
 }

--- a/app/src/community/java/com/twilio/video/app/security/SecurePreferences.kt
+++ b/app/src/community/java/com/twilio/video/app/security/SecurePreferences.kt
@@ -5,4 +5,6 @@ interface SecurePreferences {
     fun putSecureString(key: String, value: String)
 
     fun getSecureString(key: String): String?
+
+    fun removeSecureString(key: String)
 }

--- a/app/src/community/java/com/twilio/video/app/security/SecurePreferencesImpl.kt
+++ b/app/src/community/java/com/twilio/video/app/security/SecurePreferencesImpl.kt
@@ -34,4 +34,8 @@ class SecurePreferencesImpl(
     override fun getSecureString(key: String): String? {
         return securePreferences.getString(key, null)
     }
+
+    override fun removeSecureString(key: String) {
+        securePreferences.edit { remove(key) }
+    }
 }

--- a/app/src/testCommunity/java/com/twilio/video/app/security/SecurePreferencesFake.kt
+++ b/app/src/testCommunity/java/com/twilio/video/app/security/SecurePreferencesFake.kt
@@ -9,4 +9,8 @@ class SecurePreferencesFake : SecurePreferences {
     }
 
     override fun getSecureString(key: String) = preferences[key]
+
+    override fun removeSecureString(key: String) {
+        preferences.remove(key)
+    }
 }


### PR DESCRIPTION
## Description

Fixed an issue where the login view was not presented after logout. Passcode key is now removed from the correct storage, key was previously removed from sharedPreferences, but it was stored in securePreferences, because of that loggedIn() check always returned true, causing the lobby to be presented instead of the login view.

## Breakdown

- Added removeSecureString(key) to the SecurePreferences interface
- Added fix to remove PASSCODE from securePreferences.

## Validation

- Manually tested

## Additional Notes

Related ticket:
 [VBLOCKS-5934:](https://twilio-engineering.atlassian.net/browse/VBLOCKS-5934) [Video] [Android] [Ahoy] Logout functionality does not work

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
