### PR TITLE
VBLOCKS-5355: Fix crash when app is backgrounded during room connection

### DIFF
--- a/app/src/main/java/com/twilio/video/app/sdk/RoomManager.kt
+++ b/app/src/main/java/com/twilio/video/app/sdk/RoomManager.kt
@@ -63,11 +63,12 @@ class RoomManager(
     var room: Room? = null
 
     fun disconnect() {
-        room?.disconnect()
+        room?.disconnect() ?: stopService(context)
     }
 
     suspend fun connect(identity: String, roomName: String) {
         sendRoomEvent(Connecting)
+        startService(context, roomName)
         connectToRoom(identity, roomName)
     }
 
@@ -90,6 +91,7 @@ class RoomManager(
 
     private fun handleTokenException(e: Exception, error: AuthServiceError? = null): Room? {
         Timber.e(e, "Failed to retrieve token")
+        stopService(context)
         sendRoomEvent(RoomEvent.TokenError(serviceError = error))
         return null
     }
@@ -152,8 +154,6 @@ class RoomManager(
                 room.sid,
             )
 
-            startService(context, room.name)
-
             setupParticipants(room)
 
             statsScheduler = StatsScheduler(this@RoomManager, room).apply { start() }
@@ -185,6 +185,8 @@ class RoomManager(
                 twilioException.code,
                 twilioException.message,
             )
+
+            stopService(context)
 
             if (twilioException.code == ROOM_MAX_PARTICIPANTS_EXCEEDED_EXCEPTION) {
                 sendRoomEvent(MaxParticipantFailure)


### PR DESCRIPTION

## Description
Fixed a crash caused by Android 14+ foreground service restrictions. Android 14+ (targetSDK=35) requires that foreground services using FOREGROUND_SERVICE_TYPE_MICROPHONE or FOREGROUND_SERVICE_TYPE_CAMERA are started while the app is in foreground state ([Foreground service types are required](https://developer.android.com/about/versions/14/changes/fgs-types-required)).
So when user backgrounded the app while connecting to room, Android blocked the foreground service from starting which caused the app to crash.

This fix starts service in a place where the app is definitely in the foreground, started by the user tapping the 'Join' button in UI.

## Breakdown

- Remove startService() from onConnected() and move it to connect()
- Add stopService() also in onConnectFailure() and handleTokenException()

## Validation

- Manually tested with physical devices

## Additional Notes

Bug ticket:
-  [VBLOCKS-5355:](https://twilio-engineering.atlassian.net/browse/VBLOCKS-5355) App crashes when backgrounded while connecting

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
