### PR TITLE
Updated to use android build tools version '35.0.1'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.178 (Not released yet)
+
+### Bug Fixes
+
+* Fix foreground service crash when app is backgrounded during room connection.
+* Pinned android build tools version to 35.0.1
+
 ## 0.177 (Jul 23, 2026)
 
 ### Bug Fixes

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,6 +72,7 @@ android {
 
         minSdkVersion 28
         targetSdkVersion 35
+        buildToolsVersion '35.0.1'
 
         versionName appVersionName
         versionCode appVersionCode


### PR DESCRIPTION
## Description

In Buildkite, the image we use has the android build tools version '35.0.1' preinstalled on it. While this project is not built in buildkite, the SDK will be soon and it maps this project it to its repo.

## Breakdown

- Made it use a specific version of the android build tools

## Validation

- compiled

## Additional Notes

None

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
